### PR TITLE
Use clang-3.6 as compiler on Trusty

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,11 @@ ENV SWIFT_BRANCH swift-3.0-release
 ENV SWIFT_VERSION swift-3.0-RELEASE 
 ENV SWIFT_PLATFORM ubuntu14.04
 
-# Install related packages
+# Install related packages and set LLVM 3.6 as the compiler
 RUN apt-get update && \
-    apt-get install -y build-essential wget clang curl libedit-dev python2.7 python2.7-dev libicu52 rsync libxml2 git && \
+    apt-get install -y build-essential wget clang-3.6 curl libedit-dev python2.7 python2.7-dev libicu52 rsync libxml2 git && \
+    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-3.6 100 && \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.6 100 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Clang 3.6 should be set as the compiler for Swift to use the preferred Gold linker.

See also:
- https://github.com/swiftdocker/docker-swift-dev/blob/master/Dockerfile#L26
- https://bugs.swift.org/browse/SR-2299
