### PR TITLE
Shippable builds for Continuous Integration

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -1,0 +1,7 @@
+build:
+    pre_ci:
+        - docker build -t testbuild .
+    ci:
+        - echo "Building $COMMIT"
+
+


### PR DESCRIPTION
An example of a successful build https://app.shippable.com/runs/586365aff6c7101000c352de/1/console

Shippable is heavily optimized for docker builds (keeping layers intact across builds and better integration with docker hub) as compared to incumbents Travis CI. 

Now you can monitor PRs or the builds directly so as to trust changes without having to manually build them. 

Of course I don't know which registry to add to, so I did not update post ci steps. 