### PR TITLE
ARG instead of ENV for selecting Swift version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,10 @@ ARG SWIFT_PLATFORM=ubuntu16.04
 ARG SWIFT_BRANCH=swift-3.0.2-release 
 ARG SWIFT_VERSION=swift-3.0.2-RELEASE
 
+ENV SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    SWIFT_BRANCH=$SWIFT_BRANCH
+    SWIFT_VERSION=$SWIFT_VERSION
+
 # Download GPG keys, signature and Swift package, then unpack and cleanup
 RUN SWIFT_URL=https://swift.org/builds/$SWIFT_BRANCH/$(echo "$SWIFT_PLATFORM" | tr -d .)/$SWIFT_VERSION/$SWIFT_VERSION-$SWIFT_PLATFORM.tar.gz \
     && curl -fSsL $SWIFT_URL -o swift.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,9 @@ RUN apt-get -q update && \
     && rm -r /var/lib/apt/lists/*
 
 # Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little
-ENV SWIFT_BRANCH=swift-3.0.2-release \
-    SWIFT_VERSION=swift-3.0.2-RELEASE \
-    SWIFT_PLATFORM=ubuntu16.04 \
-    PATH=/usr/bin:$PATH
+ARG SWIFT_PLATFORM=ubuntu16.04
+ARG SWIFT_BRANCH=swift-3.0.2-release 
+ARG SWIFT_VERSION=swift-3.0.2-RELEASE
 
 # Download GPG keys, signature and Swift package, then unpack and cleanup
 RUN SWIFT_URL=https://swift.org/builds/$SWIFT_BRANCH/$(echo "$SWIFT_PLATFORM" | tr -d .)/$SWIFT_VERSION/$SWIFT_VERSION-$SWIFT_PLATFORM.tar.gz \


### PR DESCRIPTION
I'm submitting this separately to the work needed for #50 / #55, but it will be helpful for those. Once this is merged the CI configuration for this project will be able to build the various different Docker images from a single Dockerfile.

Using an ARG directive means that we can parameterise the Docker images we are building by passing `--build-arg SWIFT_...=...` to the "docker build" command.

ARG values are still exposed to RUN commands like ENV, but are not persisted in the final image.

Example usage:

```
docker build \
-t swift:2017-01-28-a \
--build-arg=SWIFT_BRANCH=development \
--build-arg SWIFT_VERSION=swift-DEVELOPMENT-SNAPSHOT-2017-01-28-a \
.
```