### PR TITLE
<Description> : Adding support for libssl-dev for projects that work with the OpenSSL bridging header.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get -q update && \
     python2.7 \
     python2.7-dev \
     libicu-dev \
+    libssl-dev \
     rsync \
     libxml2 \
     git \


### PR DESCRIPTION
<Type> : fix/config

Kitura was failing its build (I was trying to build Kitura in the container in a hackathon). 

note: you may be able to install openssl using your system-packager:

    apt-get install openssl libssl-dev

    Compile Swift Module 'Socket' (3 sources)
    Compile Swift Module 'LoggerAPI' (1 sources)
    Compile Swift Module 'KituraTemplateEngine' (1 sources)
    Compile Swift Module 'SwiftyJSON' (2 sources)
    Compile Swift Module 'SSLService' (1 sources)
    /Kitura/Packages/OpenSSL-0.3.1/module.modulemap:18:15: error: header    '/usr/include/openssl/conf.h' not found
       header "/usr/include/openssl/conf.h"
              ^
    /Kitura/Packages/SSLService-0.12.21/Sources/SSLService.swift:26:9: error: could not build    Objective-C module 'OpenSSL'
        import OpenSSL

After the fix

    Compile Swift Module 'Socket' (3 sources)
    Compile Swift Module 'LoggerAPI' (1 sources) 
    Compile Swift Module 'KituraTemplateEngine' (1 sources)
    Compile Swift Module 'SwiftyJSON' (2 sources)
    Compile Swift Module 'SSLService' (1 sources)
    Compile CHTTPParser http_parser.c
    Compile CHTTPParser utils.c
    Linking CHTTPParser
    Compile Swift Module 'KituraNet' (35 sources)
    Compile Swift Module 'Kitura' (42 sources)