### PR TITLE
Adding support pkg-config for SwiftPM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get -q update && \
     libxml2 \
     git \
     libcurl4-openssl-dev \
+    pkg-config \
     && update-alternatives --quiet --install /usr/bin/clang clang /usr/bin/clang-3.6 100 \
     && update-alternatives --quiet --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.6 100 \
     && rm -r /var/lib/apt/lists/*


### PR DESCRIPTION
If pkg-config is not installed, the Swift Package Manager may fail to build.

https://github.com/tid-kijyun/Kanna/issues/134#issuecomment-277918602

> NOTE: This feature does not require pkg-config to be installed. However, if installed it will used to find additional platform specific pc filelocations which might be unknown to SwiftPM.
https://github.com/apple/swift-package-manager/blob/master/Documentation/Reference.md#pkgconfig