### PR TITLE
Upgrading clang to 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get -q update && \
     apt-get -q install -y \
     make \
     libc6-dev \
-    clang-3.6 \
+    clang-3.8 \
     curl \
     libedit-dev \
     python2.7 \
@@ -17,8 +17,8 @@ RUN apt-get -q update && \
     git \
     libcurl4-openssl-dev \
     pkg-config \
-    && update-alternatives --quiet --install /usr/bin/clang clang /usr/bin/clang-3.6 100 \
-    && update-alternatives --quiet --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.6 100 \
+    && update-alternatives --quiet --install /usr/bin/clang clang /usr/bin/clang-3.8 100 \
+    && update-alternatives --quiet --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.8 100 \
     && rm -r /var/lib/apt/lists/*
 
 # Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little


### PR DESCRIPTION
Somehow, #58 never got merged to the main branch; here it is again.