### PR TITLE
Use Dockerfile.template as root source of truth.

### DIFF
--- a/3.1/Dockerfile
+++ b/3.1/Dockerfile
@@ -1,0 +1,61 @@
+FROM ubuntu:16.04
+LABEL maintainer="Haris Amin <aminharis7@gmail.com>"
+LABEL Description="Docker Container for the Apple's Swift programming language"
+
+# Install related packages and set LLVM 3.8 as the compiler
+RUN apt-get -q update && \
+    apt-get -q install -y \
+    make \
+    libc6-dev \
+    clang-3.8 \
+    curl \
+    libedit-dev \
+    libpython2.7 \
+    libicu-dev \
+    libssl-dev \
+    libxml2 \
+    git \
+    libcurl4-openssl-dev \
+    pkg-config \
+    && update-alternatives --quiet --install /usr/bin/clang clang /usr/bin/clang-3.8 100 \
+    && update-alternatives --quiet --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.8 100 \
+    && rm -r /var/lib/apt/lists/*    
+
+# Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little
+ARG SWIFT_PLATFORM=ubuntu16.04
+ARG SWIFT_BRANCH=swift-3.1.1-release
+ARG SWIFT_VERSION=swift-3.1.1-RELEASE
+
+ENV SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    SWIFT_BRANCH=$SWIFT_BRANCH \
+    SWIFT_VERSION=$SWIFT_VERSION
+
+# Download GPG keys, signature and Swift package, then unpack, cleanup and execute permissions for foundation libs
+RUN SWIFT_URL=https://swift.org/builds/$SWIFT_BRANCH/$(echo "$SWIFT_PLATFORM" | tr -d .)/$SWIFT_VERSION/$SWIFT_VERSION-$SWIFT_PLATFORM.tar.gz \
+    && curl -fSsL $SWIFT_URL -o swift.tar.gz \
+    && curl -fSsL $SWIFT_URL.sig -o swift.tar.gz.sig \
+    && export GNUPGHOME="$(mktemp -d)" \
+    && set -e; \
+        for key in \
+      # pub   rsa4096 2017-11-07 [SC] [expires: 2019-11-07]
+      # 8513444E2DA36B7C1659AF4D7638F1FB2B2B08C4
+      # uid           [ unknown] Swift Automatic Signing Key #2 <swift-infrastructure@swift.org>
+          8513444E2DA36B7C1659AF4D7638F1FB2B2B08C4 \
+      # pub   4096R/91D306C6 2016-05-31 [expires: 2018-05-31]
+      #       Key fingerprint = A3BA FD35 56A5 9079 C068  94BD 63BC 1CFE 91D3 06C6
+      # uid                  Swift 3.x Release Signing Key <swift-infrastructure@swift.org>
+          A3BAFD3556A59079C06894BD63BC1CFE91D306C6 \
+      # pub   4096R/71E1B235 2016-05-31 [expires: 2019-06-14]
+      #       Key fingerprint = 5E4D F843 FB06 5D7F 7E24  FBA2 EF54 30F0 71E1 B235
+      # uid                  Swift 4.x Release Signing Key <swift-infrastructure@swift.org>          
+          5E4DF843FB065D7F7E24FBA2EF5430F071E1B235 \
+        ; do \
+          gpg --quiet --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+        done \
+    && gpg --batch --verify --quiet swift.tar.gz.sig swift.tar.gz \
+    && tar -xzf swift.tar.gz --directory / --strip-components=1 \
+    && rm -r "$GNUPGHOME" swift.tar.gz.sig swift.tar.gz \
+    && chmod -R o+r /usr/lib/swift 
+
+# Print Installed Swift Version
+RUN swift --version

--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -1,0 +1,61 @@
+FROM ubuntu:16.04
+LABEL maintainer="Haris Amin <aminharis7@gmail.com>"
+LABEL Description="Docker Container for the Apple's Swift programming language"
+
+# Install related packages and set LLVM 3.8 as the compiler
+RUN apt-get -q update && \
+    apt-get -q install -y \
+    make \
+    libc6-dev \
+    clang-3.8 \
+    curl \
+    libedit-dev \
+    libpython2.7 \
+    libicu-dev \
+    libssl-dev \
+    libxml2 \
+    git \
+    libcurl4-openssl-dev \
+    pkg-config \
+    && update-alternatives --quiet --install /usr/bin/clang clang /usr/bin/clang-3.8 100 \
+    && update-alternatives --quiet --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.8 100 \
+    && rm -r /var/lib/apt/lists/*    
+
+# Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little
+ARG SWIFT_PLATFORM=ubuntu16.04
+ARG SWIFT_BRANCH=swift-4.0.2-release
+ARG SWIFT_VERSION=swift-4.0.2-RELEASE
+
+ENV SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    SWIFT_BRANCH=$SWIFT_BRANCH \
+    SWIFT_VERSION=$SWIFT_VERSION
+
+# Download GPG keys, signature and Swift package, then unpack, cleanup and execute permissions for foundation libs
+RUN SWIFT_URL=https://swift.org/builds/$SWIFT_BRANCH/$(echo "$SWIFT_PLATFORM" | tr -d .)/$SWIFT_VERSION/$SWIFT_VERSION-$SWIFT_PLATFORM.tar.gz \
+    && curl -fSsL $SWIFT_URL -o swift.tar.gz \
+    && curl -fSsL $SWIFT_URL.sig -o swift.tar.gz.sig \
+    && export GNUPGHOME="$(mktemp -d)" \
+    && set -e; \
+        for key in \
+      # pub   rsa4096 2017-11-07 [SC] [expires: 2019-11-07]
+      # 8513444E2DA36B7C1659AF4D7638F1FB2B2B08C4
+      # uid           [ unknown] Swift Automatic Signing Key #2 <swift-infrastructure@swift.org>
+          8513444E2DA36B7C1659AF4D7638F1FB2B2B08C4 \
+      # pub   4096R/91D306C6 2016-05-31 [expires: 2018-05-31]
+      #       Key fingerprint = A3BA FD35 56A5 9079 C068  94BD 63BC 1CFE 91D3 06C6
+      # uid                  Swift 3.x Release Signing Key <swift-infrastructure@swift.org>
+          A3BAFD3556A59079C06894BD63BC1CFE91D306C6 \
+      # pub   4096R/71E1B235 2016-05-31 [expires: 2019-06-14]
+      #       Key fingerprint = 5E4D F843 FB06 5D7F 7E24  FBA2 EF54 30F0 71E1 B235
+      # uid                  Swift 4.x Release Signing Key <swift-infrastructure@swift.org>          
+          5E4DF843FB065D7F7E24FBA2EF5430F071E1B235 \
+        ; do \
+          gpg --quiet --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+        done \
+    && gpg --batch --verify --quiet swift.tar.gz.sig swift.tar.gz \
+    && tar -xzf swift.tar.gz --directory / --strip-components=1 \
+    && rm -r "$GNUPGHOME" swift.tar.gz.sig swift.tar.gz \
+    && chmod -R o+r /usr/lib/swift 
+
+# Print Installed Swift Version
+RUN swift --version

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -23,8 +23,8 @@ RUN apt-get -q update && \
 
 # Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little
 ARG SWIFT_PLATFORM=ubuntu16.04
-ARG SWIFT_BRANCH=swift-4.0.2-release
-ARG SWIFT_VERSION=swift-4.0.2-RELEASE
+ARG SWIFT_BRANCH=v$SWIFT_BRANCH
+ARG SWIFT_VERSION=v$SWIFT_VERSION
 
 ENV SWIFT_PLATFORM=$SWIFT_PLATFORM \
     SWIFT_BRANCH=$SWIFT_BRANCH \
@@ -37,14 +37,10 @@ RUN SWIFT_URL=https://swift.org/builds/$SWIFT_BRANCH/$(echo "$SWIFT_PLATFORM" | 
     && export GNUPGHOME="$(mktemp -d)" \
     && set -e; \
         for key in \
-      # pub   4096R/412B37AD 2015-11-19 [expires: 2017-11-18]
-      #       Key fingerprint = 7463 A81A 4B2E EA1B 551F  FBCF D441 C977 412B 37AD
-      # uid                  Swift Automatic Signing Key #1 <swift-infrastructure@swift.org>
-          7463A81A4B2EEA1B551FFBCFD441C977412B37AD \
-      # pub   4096R/21A56D5F 2015-11-28 [expires: 2017-11-27]
-      #       Key fingerprint = 1BE1 E29A 084C B305 F397  D62A 9F59 7F4D 21A5 6D5F
-      # uid                  Swift 2.2 Release Signing Key <swift-infrastructure@swift.org>
-          1BE1E29A084CB305F397D62A9F597F4D21A56D5F \
+      # pub   rsa4096 2017-11-07 [SC] [expires: 2019-11-07]
+      # 8513444E2DA36B7C1659AF4D7638F1FB2B2B08C4
+      # uid           [ unknown] Swift Automatic Signing Key #2 <swift-infrastructure@swift.org>
+          8513444E2DA36B7C1659AF4D7638F1FB2B2B08C4 \
       # pub   4096R/91D306C6 2016-05-31 [expires: 2018-05-31]
       #       Key fingerprint = A3BA FD35 56A5 9079 C068  94BD 63BC 1CFE 91D3 06C6
       # uid                  Swift 3.x Release Signing Key <swift-infrastructure@swift.org>

--- a/shippable.yml
+++ b/shippable.yml
@@ -1,5 +1,6 @@
 build:
     pre_ci:
-        - docker build -t testbuild .
+        - docker build ./4.0
+        - docker build ./3.1
     ci:
         - echo "Building $COMMIT"


### PR DESCRIPTION
This commit takes the lead from
[docker-node](https://github.com/nodejs/docker-node), separating
supported versions into their own folders, using Dockerfiles generated
from template. This commit closes #92 by backporting Clang 3.8 into 3.1.

I have also removed two soon to expire PGP keys from the file and added the new automation key.