### PR TITLE
Update to Swift 4.1.3

### DIFF
--- a/4.1/Dockerfile
+++ b/4.1/Dockerfile
@@ -24,8 +24,8 @@ RUN apt-get -q update && \
 
 # Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little
 ARG SWIFT_PLATFORM=ubuntu16.04
-ARG SWIFT_BRANCH=swift-4.1.2-release
-ARG SWIFT_VERSION=swift-4.1.2-RELEASE
+ARG SWIFT_BRANCH=swift-4.1.3-release
+ARG SWIFT_VERSION=swift-4.1.3-RELEASE
 
 ENV SWIFT_PLATFORM=$SWIFT_PLATFORM \
     SWIFT_BRANCH=$SWIFT_BRANCH \

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -24,5 +24,5 @@ We support the latest stable version of Docker only. This is currently 18.03.
 - This project will only support the latest two minor versions of the latest major version of Swift.
 - This project will only support the latest patch version of any major version.
 
-Currently, we are supporting `4.1.2`, `4.0.3` and `3.1.1`.
+Currently, we are supporting `4.1.3`, `4.0.3` and `3.1.1`.
 


### PR DESCRIPTION
Swift 4.1.3 includes an important fix for the Decimal type on Linux, see 
[SR-7650](https://bugs.swift.org/browse/SR-7650).