### PR TITLE
Cleanups prior to repo move

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,46 +1,55 @@
-# Contributor Covenant Code of Conduct
+# Code of Conduct
+To be a truly great community, Swift.org needs to welcome developers from all walks of life,
+with different backgrounds, and with a wide range of experience. A diverse and friendly
+community will have more great ideas, more unique perspectives, and produce more great 
+code. We will work diligently to make the Swift community welcoming to everyone.
 
-## Our Pledge
+To give clarity of what is expected of our members, Swift.org has adopted the code of conduct 
+defined by [contributor-covenant.org](https://www.contributor-covenant.org). This document is used across many open source 
+communities, and we think it articulates our values well. The full text is copied below:
 
-In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+### Contributor Code of Conduct v1.3
+As contributors and maintainers of this project, and in the interest of fostering an open and 
+welcoming community, we pledge to respect all people who contribute through reporting 
+issues, posting feature requests, updating documentation, submitting pull requests or patches, 
+and other activities.
 
-## Our Standards
-
-Examples of behavior that contributes to creating a positive environment include:
-
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+We are committed to making participation in this project a harassment-free experience for 
+everyone, regardless of level of experience, gender, gender identity and expression, sexual 
+orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or 
+nationality.
 
 Examples of unacceptable behavior by participants include:
+- The use of sexualized language or imagery
+- Personal attacks
+- Trolling or insulting/derogatory comments
+- Public or private harassment
+- Publishing other’s private information, such as physical or electronic addresses, without explicit permission
+- Other unethical or unprofessional conduct
 
-* The use of sexualized language or imagery and unwelcome sexual attention or advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a professional setting
+Project maintainers have the right and responsibility to remove, edit, or reject comments, 
+commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of 
+Conduct, or to ban temporarily or permanently any contributor for other behaviors that they 
+deem inappropriate, threatening, offensive, or harmful.
 
-## Our Responsibilities
+By adopting this Code of Conduct, project maintainers commit themselves to fairly and 
+consistently applying these principles to every aspect of managing this project. Project 
+maintainers who do not follow or enforce the Code of Conduct may be permanently removed 
+from the project team.
 
-Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+This code of conduct applies both within project spaces and in public spaces when an 
+individual is representing the project or its community.
 
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by 
+contacting a project maintainer at [conduct@swift.org](mailto:conduct@swift.org). All complaints will be reviewed and 
+investigated and will result in a response that is deemed necessary and appropriate to the 
+circumstances. Maintainers are obligated to maintain confidentiality with regard to the reporter 
+of an incident.
 
-## Scope
+*This policy is adapted from the Contributor Code of Conduct [version 1.3.0](http://contributor-covenant.org/version/1/3/0/).*
 
-This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
-
-## Enforcement
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at me@swizzlr.co. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
-
-Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
-
-## Attribution
-
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
-
-[homepage]: http://contributor-covenant.org
-[version]: http://contributor-covenant.org/version/1/4/
+### Reporting
+A working group of community members is committed to promptly addressing any [reported 
+issues](mailto:conduct@swift.org). Working group members are volunteers appointed by the project lead, with a 
+preference for individuals with varied backgrounds and perspectives. Membership is expected 
+to change regularly, and may grow or shrink.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -9,13 +9,11 @@ This is a community supported initiative to provide high quality Swift Docker im
 ## Relation to `official-images`
 This is the source repository for the official Docker image of Swift. We are necessarily conservative in what we add to this repo for that reason.
 
-However, the repo is also available as `swiftdocker/swift` on Docker Hub as an automated build. All older tags will remain there, and we may be able to provide pre-release builds here too.
-
 ## Support Commitments
 
 ### Docker Versions
 
-We support the latest stable version of Docker only. This is currently 18.03.
+We support the latest stable version of Docker only.
 
 ### Swift Versions
 

--- a/shippable.yml
+++ b/shippable.yml
@@ -1,8 +1,0 @@
-build:
-    pre_ci:
-        - docker build ./4.2
-        - docker build ./4.1
-        - docker build ./4.0
-        - docker build ./3.1
-    ci:
-        - echo "Building $COMMIT"


### PR DESCRIPTION
- Make code of conduct consistent with other swift.org repos
- Remove shippable.yml as we will be using Swift CI in future
- Reword PROJECT.md slightly