### PR TITLE
5.0: optimise installed packages

### DIFF
--- a/5.0/ubuntu/16.04/Dockerfile
+++ b/5.0/ubuntu/16.04/Dockerfile
@@ -2,24 +2,22 @@ FROM ubuntu:16.04
 LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL Description="Docker Container for the Swift programming language"
 
-# Install related packages and set LLVM 3.8 as the compiler
 RUN apt-get -q update && \
     apt-get -q install -y \
-    make \
-    libc6-dev \
-    clang-3.8 \
-    curl \
-    libedit-dev \
-    libpython2.7 \
-    libicu-dev \
-    libssl-dev \
+    libatomic1 \
+    libbsd0 \
+    libcurl3 \
     libxml2 \
+    libedit2 \
+    libsqlite3-0 \
+    libc6-dev \
+    binutils \
+    libgcc-5-dev \
+    libstdc++-5-dev \
+    libpython2.7 \
     tzdata \
     git \
-    libcurl4-openssl-dev \
     pkg-config \
-    && update-alternatives --quiet --install /usr/bin/clang clang /usr/bin/clang-3.8 100 \
-    && update-alternatives --quiet --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.8 100 \
     && rm -r /var/lib/apt/lists/*    
 
 # Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little
@@ -33,8 +31,12 @@ ENV SWIFT_PLATFORM=$SWIFT_PLATFORM \
 
 # Download GPG keys, signature and Swift package, then unpack, cleanup and execute permissions for foundation libs
 RUN SWIFT_URL=https://swift.org/builds/$SWIFT_BRANCH/$(echo "$SWIFT_PLATFORM" | tr -d .)/$SWIFT_VERSION/$SWIFT_VERSION-$SWIFT_PLATFORM.tar.gz \
+    && apt-get -q update \
+    && apt-get -q install -y curl \
     && curl -fSsL $SWIFT_URL -o swift.tar.gz \
     && curl -fSsL $SWIFT_URL.sig -o swift.tar.gz.sig \
+    && apt-get purge -y curl \
+    && apt-get -y autoremove \
     && export GNUPGHOME="$(mktemp -d)" \
     && set -e; \
         for key in \

--- a/5.0/ubuntu/18.04/Dockerfile
+++ b/5.0/ubuntu/18.04/Dockerfile
@@ -2,24 +2,22 @@ FROM ubuntu:18.04
 LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL Description="Docker Container for the Swift programming language"
 
-# Install related packages and set LLVM 3.9 as the compiler
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
     apt-get -q install -y \
-    make \
-    libc6-dev \
-    clang-3.9 \
-    curl \
-    libedit-dev \
-    libpython2.7 \
-    libicu-dev \
-    libssl-dev \
+    libatomic1 \
+    libbsd0 \
+    libcurl4 \
     libxml2 \
+    libedit2 \
+    libsqlite3-0 \
+    libc6-dev \
+    binutils \
+    libgcc-5-dev \
+    libstdc++-5-dev \
+    libpython2.7 \
     tzdata \
     git \
-    libcurl4-openssl-dev \
     pkg-config \
-    && update-alternatives --quiet --install /usr/bin/clang clang /usr/bin/clang-3.9 100 \
-    && update-alternatives --quiet --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.9 100 \
     && rm -r /var/lib/apt/lists/*
 
 # Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little
@@ -33,8 +31,12 @@ ENV SWIFT_PLATFORM=$SWIFT_PLATFORM \
 
 # Download GPG keys, signature and Swift package, then unpack, cleanup and execute permissions for foundation libs
 RUN SWIFT_URL=https://swift.org/builds/$SWIFT_BRANCH/$(echo "$SWIFT_PLATFORM" | tr -d .)/$SWIFT_VERSION/$SWIFT_VERSION-$SWIFT_PLATFORM.tar.gz \
+    && apt-get update \
+    && apt-get install -y curl \
     && curl -fSsL $SWIFT_URL -o swift.tar.gz \
     && curl -fSsL $SWIFT_URL.sig -o swift.tar.gz.sig \
+    && apt-get purge -y curl \
+    && apt-get -y autoremove \
     && export GNUPGHOME="$(mktemp -d)" \
     && set -e; \
         for key in \


### PR DESCRIPTION
The current Swift 5.0 `Dockerfile`s are a continuation of the images shipped in earlier releases. 

However, there have been some significant changes to the Linux toolchains in Swift 5.0 which mean we have the opportunity to optimise the system packages that are installed in the images. This will significantly reduce the size of the images, benefitting all users.

Specifically, the following major changes occurred in Swift 5:

- Foundation no longer depends on the system ICU but ships its own
- The compiler no longer depends on a system `clang` but ships its own

In addition, we can make a number of other improvements to the images by removing unnecessary packages and only installing those which are genuinely required to build and run Swift programs.

I have spent time [working out the actual requirements of the toolchain](https://forums.swift.org/t/which-clang-package-should-we-install/20542/20). I think the following packages are required:

Runtime requirements:
- `libatomic1` - all Swift programs link this
- `libbsd0` - all Swift programs link this (for `libdispatch`)
- `libcurl4` - Foundation links this
- `libxml2` - Foundation links this
- `tzdata` - Foundation

Build requirements:
- `libc6-dev` - Compiler
- `binutils` - for `gold` linker
- `libgcc-5-dev` - Compiler
- `libstdc++-5-dev` - Compiler/stdlib
- `libedit2` - Package manager
- `libsqlite3-0` - Package manager
- `git` - Package manager
- `pkg-config` - Package manager
- `libpython2.7` - REPL

Making these changes has the following effect to image size:

| Image | Before | After |
| - | - | - |
| 16.04 | 1.69GB | 1.37GB |
| 18.04 | 1.81GB | 1.37GB |