### PR TITLE
Change description label to be lowercase

### DIFF
--- a/3.1/Dockerfile
+++ b/3.1/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 LABEL maintainer="Haris Amin <aminharis7@gmail.com>"
-LABEL Description="Docker Container for the Apple's Swift programming language"
+LABEL description="Docker Container for the Apple's Swift programming language"
 
 # Install related packages and set LLVM 3.8 as the compiler
 RUN apt-get -q update && \

--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 LABEL maintainer="Haris Amin <aminharis7@gmail.com>"
-LABEL Description="Docker Container for the Apple's Swift programming language"
+LABEL description="Docker Container for the Apple's Swift programming language"
 
 # Install related packages and set LLVM 3.8 as the compiler
 RUN apt-get -q update && \

--- a/4.1/Dockerfile
+++ b/4.1/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 LABEL maintainer="Haris Amin <aminharis7@gmail.com>"
-LABEL Description="Docker Container for the Apple's Swift programming language"
+LABEL description="Docker Container for the Apple's Swift programming language"
 
 # Install related packages and set LLVM 3.8 as the compiler
 RUN apt-get -q update && \

--- a/4.2/ubuntu/16.04/Dockerfile
+++ b/4.2/ubuntu/16.04/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
-LABEL Description="Docker Container for the Swift programming language"
+LABEL description="Docker Container for the Swift programming language"
 
 # Install related packages and set LLVM 3.8 as the compiler
 RUN apt-get -q update && \

--- a/4.2/ubuntu/18.04/Dockerfile
+++ b/4.2/ubuntu/18.04/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
-LABEL Description="Docker Container for the Swift programming language"
+LABEL description="Docker Container for the Swift programming language"
 
 # Install related packages and set LLVM 3.9 as the compiler
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \

--- a/5.0/ubuntu/16.04/Dockerfile
+++ b/5.0/ubuntu/16.04/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
-LABEL Description="Docker Container for the Swift programming language"
+LABEL description="Docker Container for the Swift programming language"
 
 RUN apt-get -q update && \
     apt-get -q install -y \

--- a/5.0/ubuntu/16.04/slim/Dockerfile
+++ b/5.0/ubuntu/16.04/slim/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
-LABEL Description="Docker Container for the Swift programming language"
+LABEL description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
     apt-get -q install -y \

--- a/5.0/ubuntu/18.04/Dockerfile
+++ b/5.0/ubuntu/18.04/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
-LABEL Description="Docker Container for the Swift programming language"
+LABEL description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
     apt-get -q install -y \

--- a/5.0/ubuntu/18.04/slim/Dockerfile
+++ b/5.0/ubuntu/18.04/slim/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
-LABEL Description="Docker Container for the Swift programming language"
+LABEL description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
     apt-get -q install -y \

--- a/5.1/ubuntu/16.04/Dockerfile
+++ b/5.1/ubuntu/16.04/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
-LABEL Description="Docker Container for the Swift programming language"
+LABEL description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
     apt-get -q install -y \

--- a/5.1/ubuntu/16.04/slim/Dockerfile
+++ b/5.1/ubuntu/16.04/slim/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
-LABEL Description="Docker Container for the Swift programming language"
+LABEL description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
     apt-get -q install -y \

--- a/5.1/ubuntu/18.04/Dockerfile
+++ b/5.1/ubuntu/18.04/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
-LABEL Description="Docker Container for the Swift programming language"
+LABEL description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
     apt-get -q install -y \

--- a/5.1/ubuntu/18.04/slim/Dockerfile
+++ b/5.1/ubuntu/18.04/slim/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
-LABEL Description="Docker Container for the Swift programming language"
+LABEL description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
     apt-get -q install -y \


### PR DESCRIPTION
I know this is pretty nit-picky but when using the Swift images I noticed that they all use the `Description` label instead of `description`. In my opinion this should be changed to go along with [the convention](https://docs.docker.com/engine/reference/builder/#label) and with the `maintainer` label used in the Swift images.