### PR TITLE
Update supported versions in PROJECT.md

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -22,4 +22,4 @@ We support the latest stable version of Docker only.
 - This project will only support the latest two minor versions of the latest major version of Swift.
 - This project will only support the latest patch version of any major version.
 
-Currently, we are supporting `4.2.1`, `4.1.3`, `4.0.3` and `3.1.1`.
+Currently, we are supporting `5.1.1`, `5.0.3`, `4.2.4`, `4.1.3` and `4.0.3`.


### PR DESCRIPTION
I’ve updated the current supported versions to be on par on what is sated here https://hub.docker.com/_/swift/.

The rules in the file are stated that only `5.1.1`, `5.0.3` and `4.2.4` are the truly one supported, but I prefer to be on par with what the docker hub is showing right now.
But I can obviously update the commit to reflect the rules.