### PR TITLE
include zlib1g-dev

### DIFF
--- a/4.2/ubuntu/16.04/Dockerfile
+++ b/4.2/ubuntu/16.04/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get -q update && \
     tzdata \
     git \
     libcurl4-openssl-dev \
+    zlib1g-dev \
     pkg-config \
     && update-alternatives --quiet --install /usr/bin/clang clang /usr/bin/clang-3.8 100 \
     && update-alternatives --quiet --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.8 100 \

--- a/4.2/ubuntu/18.04/Dockerfile
+++ b/4.2/ubuntu/18.04/Dockerfile
@@ -17,6 +17,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     tzdata \
     git \
     libcurl4-openssl-dev \
+    zlib1g-dev \
     pkg-config \
     && update-alternatives --quiet --install /usr/bin/clang clang /usr/bin/clang-3.9 100 \
     && update-alternatives --quiet --install /usr/bin/clang++ clang++ /usr/bin/clang++-3.9 100 \

--- a/5.0/ubuntu/16.04/Dockerfile
+++ b/5.0/ubuntu/16.04/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get -q update && \
     binutils \
     libgcc-5-dev \
     libstdc++-5-dev \
+    zlib1g-dev \
     libpython2.7 \
     tzdata \
     git \

--- a/5.0/ubuntu/18.04/Dockerfile
+++ b/5.0/ubuntu/18.04/Dockerfile
@@ -14,6 +14,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     binutils \
     libgcc-5-dev \
     libstdc++-5-dev \
+    zlib1g-dev \
     libpython2.7 \
     tzdata \
     git \

--- a/5.1/ubuntu/16.04/Dockerfile
+++ b/5.1/ubuntu/16.04/Dockerfile
@@ -13,6 +13,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     binutils \
     libgcc-5-dev \
     libstdc++-5-dev \
+    zlib1g-dev \
     libpython2.7 \
     tzdata \
     git \

--- a/5.1/ubuntu/18.04/Dockerfile
+++ b/5.1/ubuntu/18.04/Dockerfile
@@ -13,6 +13,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     binutils \
     libgcc-5-dev \
     libstdc++-5-dev \
+    zlib1g-dev \
     libpython2.7 \
     tzdata \
     git \

--- a/nightly-5.2/ubuntu/16.04/Dockerfile
+++ b/nightly-5.2/ubuntu/16.04/Dockerfile
@@ -13,6 +13,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     binutils \
     libgcc-5-dev \
     libstdc++-5-dev \
+    zlib1g-dev \
     libpython2.7 \
     tzdata \
     git \

--- a/nightly-5.2/ubuntu/18.04/Dockerfile
+++ b/nightly-5.2/ubuntu/18.04/Dockerfile
@@ -13,6 +13,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     binutils \
     libgcc-5-dev \
     libstdc++-5-dev \
+    zlib1g-dev \
     libpython2.7 \
     tzdata \
     git \

--- a/nightly-master/ubuntu/16.04/Dockerfile
+++ b/nightly-master/ubuntu/16.04/Dockerfile
@@ -13,6 +13,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     binutils \
     libgcc-5-dev \
     libstdc++-5-dev \
+    zlib1g-dev \
     libpython2.7 \
     tzdata \
     git \

--- a/nightly-master/ubuntu/18.04/Dockerfile
+++ b/nightly-master/ubuntu/18.04/Dockerfile
@@ -13,6 +13,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     binutils \
     libgcc-5-dev \
     libstdc++-5-dev \
+    zlib1g-dev \
     libpython2.7 \
     tzdata \
     git \


### PR DESCRIPTION
Motivation:

Any UNIX system requires zlib even for the most basic tasks so it's not
a surprise the Swift images also include zlib1g-dev. Unfortunately, we
missed shipping the development headers. That means that despite
shipping zlib, we can't use it.

Modification:

Add zlib1g-dev to make the zlib binaries actually usable.

Result:

More programs will build using the Swift docker images.