### PR TITLE
Dockerfile for Debian 10/buster

### DIFF
--- a/swift-ci/master/debian/10/Dockerfile
+++ b/swift-ci/master/debian/10/Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND="noninteractive"
 
 RUN apt-get update
 
-RUN apt-get --no-install-recommends install -y     \
+RUN apt-get -y --no-install-recommends install \
   build-essential       \
   clang                 \
   cmake                 \
@@ -30,7 +30,8 @@ RUN apt-get --no-install-recommends install -y     \
   tzdata                \
   unzip                 \
   vim                   \
-  uuid-dev
+  uuid-dev		\
+  ca-certificates
 
 USER build-user
 

--- a/swift-ci/master/debian/10/Dockerfile
+++ b/swift-ci/master/debian/10/Dockerfile
@@ -1,0 +1,37 @@
+FROM debian:10
+
+RUN groupadd -g 998 build-user && \
+    useradd -m -r -u 998 -g build-user build-user
+
+ENV DEBIAN_FRONTEND="noninteractive"
+
+RUN apt-get update
+
+RUN apt-get --no-install-recommends install -y     \
+  build-essential       \
+  clang                 \
+  cmake                 \
+  git                   \
+  icu-devtools          \
+  libcurl4-openssl-dev  \
+  libedit-dev           \
+  libicu-dev            \
+  libncurses5-dev       \
+  libsqlite3-dev        \
+  libxml2-dev           \
+  ninja-build           \
+  python                \
+  python-dev            \
+  python-six            \
+  pkg-config            \
+  rsync                 \
+  swig                  \
+  systemtap-sdt-dev     \
+  tzdata                \
+  unzip                 \
+  vim                   \
+  uuid-dev
+
+USER build-user
+
+WORKDIR /home/build-user

--- a/swift-ci/master/debian/9/Dockerfile
+++ b/swift-ci/master/debian/9/Dockerfile
@@ -5,9 +5,9 @@ RUN groupadd -g 998 build-user && \
 
 ENV DEBIAN_FRONTEND="noninteractive"
 
-RUN apt update
+RUN apt-get update
 
-RUN apt -y install      \
+RUN apt-get -y --no-install-recommends install \
   build-essential       \
   clang                 \
   cmake                 \
@@ -30,7 +30,8 @@ RUN apt -y install      \
   tzdata                \
   unzip                 \
   vim                   \
-  uuid-dev
+  uuid-dev		\
+  ca-certificates
 
 USER build-user
 


### PR DESCRIPTION
Based on Debian 9 but added  option --no-install-recommends which make the image size go from 1.07GB to 843MB
