### PR TITLE
Make the `zlib-devel` package available in CentOS 8 and AmazonLinux2 images

### DIFF
--- a/nightly-master/amazonlinux/2/Dockerfile
+++ b/nightly-master/amazonlinux/2/Dockerfile
@@ -17,7 +17,8 @@ RUN yum -y update && yum -y install \
   libuuid \
   libxml2 \
   tar \
-  tzdata
+  tzdata \
+  zlib-devel
 
 # Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little
 

--- a/nightly-master/centos/8/Dockerfile
+++ b/nightly-master/centos/8/Dockerfile
@@ -16,7 +16,8 @@ RUN yum -y update && yum install --enablerepo=PowerTools -y \
   libstdc++-static \
   pkg-config \
   python2 \
-  sqlite
+  sqlite \
+  zlib-devel
 
 RUN ln -s /usr/bin/python2 /usr/bin/python
 


### PR DESCRIPTION
The intention of this change is to add to out-of-the-box usability for the new eimages and improve consistency between the various platforms. Justifications:

- While not a dependency of Swift at runtime on any OS, the `libz` headers and libraries are commonly required by widely-used libraries such as `swift-nio-extras` and Vapor.
- The equivalent `zlib1g-dev` package is provided by all non-slim Ubuntu images.
- The Docker images resulting from this change were less than 60KB larger in local testing.