### PR TITLE
Added Dockerfiles for Fedora 32 and Fedora Rawhide

### DIFF
--- a/swift-ci/master/fedora/32/Dockerfile
+++ b/swift-ci/master/fedora/32/Dockerfile
@@ -1,0 +1,32 @@
+FROM fedora:32
+
+RUN groupadd -g 42 build-user && \
+    useradd -m -r -u 42 -g build-user build-user
+
+RUN dnf -y update && dnf install -y \
+    clang                       \
+    cmake                       \
+    git                         \
+    libblocksruntime-static     \
+    libbsd-devel                \
+    libcurl-devel               \
+    libedit-devel               \
+    libicu-devel                \
+    libsqlite3x-devel           \
+    libuuid-devel               \
+    libxml2-devel               \
+    make                        \
+    ninja-build                 \
+    python-unversioned-command  \
+    python27                    \
+    python3                     \
+    python3-devel               \
+    python3-distro              \
+    python3-six                 \
+    rsync                       \
+    swig 
+
+USER build-user
+
+WORKDIR /home/build-user
+

--- a/swift-ci/master/fedora/rawhide/Dockerfile
+++ b/swift-ci/master/fedora/rawhide/Dockerfile
@@ -1,0 +1,32 @@
+FROM fedora:rawhide
+
+RUN groupadd -g 42 build-user && \
+    useradd -m -r -u 42 -g build-user build-user
+
+RUN dnf -y update && dnf install -y \
+    clang                       \
+    cmake                       \
+    git                         \
+    libblocksruntime-static     \
+    libbsd-devel                \
+    libcurl-devel               \
+    libedit-devel               \
+    libicu-devel                \
+    libsqlite3x-devel           \
+    libuuid-devel               \
+    libxml2-devel               \
+    make                        \
+    ninja-build                 \
+    python-unversioned-command  \
+    python27                    \
+    python3                     \
+    python3-devel               \
+    python3-distro              \
+    python3-six                 \
+    rsync                       \
+    swig 
+
+USER build-user
+
+WORKDIR /home/build-user
+


### PR DESCRIPTION
Thanks to the merging of [this PR](https://github.com/apple/llvm-project/pull/1315) Fedora 32 (current) and Fedora Rawhide (always the next version of Fedora) can now be successfully built from master. 