### PR TITLE
add slim images for cents8 and al2

### DIFF
--- a/5.2/amazonlinux/2/slim/Dockerfile
+++ b/5.2/amazonlinux/2/slim/Dockerfile
@@ -2,24 +2,6 @@ FROM amazonlinux:2
 LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL description="Docker Container for the Swift programming language"
 
-RUN yum -y update && yum -y install \
-  binutils \
-  gcc \
-  git \
-  glibc-static \
-  gzip \
-  libbsd \
-  libcurl \
-  libedit \
-  libicu \
-  libsqlite \
-  libstdc++-static \
-  libuuid \
-  libxml2 \
-  tar \
-  tzdata \
-  zlib-devel
-
 # Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little
 
 # pub   4096R/ED3D1561 2019-03-22 [expires: 2021-03-21]
@@ -47,9 +29,8 @@ RUN set -e; \
     && gpg --batch --quiet --keyserver ha.pool.sks-keyservers.net --recv-keys "$SWIFT_SIGNING_KEY" \
     && gpg --batch --verify swift.tar.gz.sig swift.tar.gz \
     # - Unpack the toolchain, set libs permissions, and clean up.
-    && tar -xzf swift.tar.gz --directory / --strip-components=1 \
+    && yum -y update && yum -y install tar gzip \
+    && tar -xzf swift.tar.gz --directory / --strip-components=1 $SWIFT_VERSION-$SWIFT_PLATFORM/usr/lib/swift/linux \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" swift.tar.gz.sig swift.tar.gz
-
-# Print Installed Swift Version
-RUN swift --version
+    && rm -rf "$GNUPGHOME" swift.tar.gz.sig swift.tar.gz \
+    && yum autoremove -y tar gzip

--- a/5.2/centos/8/slim/Dockerfile
+++ b/5.2/centos/8/slim/Dockerfile
@@ -1,24 +1,6 @@
-FROM amazonlinux:2
+FROM centos:8
 LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL description="Docker Container for the Swift programming language"
-
-RUN yum -y update && yum -y install \
-  binutils \
-  gcc \
-  git \
-  glibc-static \
-  gzip \
-  libbsd \
-  libcurl \
-  libedit \
-  libicu \
-  libsqlite \
-  libstdc++-static \
-  libuuid \
-  libxml2 \
-  tar \
-  tzdata \
-  zlib-devel
 
 # Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little
 
@@ -26,7 +8,7 @@ RUN yum -y update && yum -y install \
 #       Key fingerprint = A62A E125 BBBF BB96 A6E0  42EC 925C C1CC ED3D 1561
 # uid                  Swift 5.x Release Signing Key <swift-infrastructure@swift.org
 ARG SWIFT_SIGNING_KEY=A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
-ARG SWIFT_PLATFORM=amazonlinux2
+ARG SWIFT_PLATFORM=centos8
 ARG SWIFT_BRANCH=swift-5.2.4-release
 ARG SWIFT_VERSION=swift-5.2.4-RELEASE
 ARG SWIFT_WEBROOT=https://swift.org/builds/
@@ -47,9 +29,6 @@ RUN set -e; \
     && gpg --batch --quiet --keyserver ha.pool.sks-keyservers.net --recv-keys "$SWIFT_SIGNING_KEY" \
     && gpg --batch --verify swift.tar.gz.sig swift.tar.gz \
     # - Unpack the toolchain, set libs permissions, and clean up.
-    && tar -xzf swift.tar.gz --directory / --strip-components=1 \
+    && tar -xzf swift.tar.gz --directory / --strip-components=1 $SWIFT_VERSION-$SWIFT_PLATFORM/usr/lib/swift/linux \
     && chmod -R o+r /usr/lib/swift \
     && rm -rf "$GNUPGHOME" swift.tar.gz.sig swift.tar.gz
-
-# Print Installed Swift Version
-RUN swift --version

--- a/nightly-master/amazonlinux/2/slim/Dockerfile
+++ b/nightly-master/amazonlinux/2/slim/Dockerfile
@@ -1,0 +1,52 @@
+FROM amazonlinux:2
+LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
+LABEL description="Docker Container for the Swift programming language"
+
+# Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little
+
+# gpg --keyid-format LONG -k FAF6989E1BC16FEA
+# pub   rsa4096/FAF6989E1BC16FEA 2019-11-07 [SC] [expires: 2021-11-06]
+#       8A7495662C3CD4AE18D95637FAF6989E1BC16FEA
+# uid                 [ unknown] Swift Automatic Signing Key #3 <swift-infrastructure@swift.org>
+ARG SWIFT_SIGNING_KEY=8A7495662C3CD4AE18D95637FAF6989E1BC16FEA
+ARG SWIFT_PLATFORM=amazonlinux
+ARG OS_MAJOR_VER=2
+ARG SWIFT_WEBROOT=https://swift.org/builds/development
+
+ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
+    SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    OS_MAJOR_VER=$OS_MAJOR_VER \
+    OS_VER=$SWIFT_PLATFORM$OS_MAJOR_VER \
+    SWIFT_WEBROOT="$SWIFT_WEBROOT/$SWIFT_PLATFORM$OS_MAJOR_VER"
+
+RUN echo "${SWIFT_WEBROOT}/latest-build.yml"
+
+RUN set -e; \
+    # - Latest Toolchain info
+    export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
+    && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \
+    && export DOWNLOAD_DIR=$(echo $download | sed "s/-${OS_VER}.tar.gz//g") \
+    && echo $DOWNLOAD_DIR > .swift_tag \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fsSL ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz \
+    ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download_signature} -o latest_toolchain.tar.gz.sig \
+    && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
+    && gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && yum -y update && yum -y install tar gzip \
+    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 ${DOWNLOAD_DIR}-${OS_VER}/usr/lib/swift/linux \
+    && chmod -R o+r /usr/lib/swift \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && yum autoremove -y tar gzip
+
+RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
+    >> /etc/bashrc; \
+    echo -e " ################################################################\n" \
+    "#\t\t\t\t\t\t\t\t#\n" \
+    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
+    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
+    "#\t\t\t\t\t\t\t\t#\n"  \
+    "################################################################\n" > /etc/motd
+
+RUN echo 'source /etc/bashrc' >> /root/.bashrc

--- a/nightly-master/centos/8/slim/Dockerfile
+++ b/nightly-master/centos/8/slim/Dockerfile
@@ -1,0 +1,48 @@
+FROM centos:8
+LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
+LABEL description="Docker Container for the Swift programming language"
+
+# Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little
+
+# gpg --keyid-format LONG -k FAF6989E1BC16FEA
+# pub   rsa4096/FAF6989E1BC16FEA 2019-11-07 [SC] [expires: 2021-11-06]
+#       8A7495662C3CD4AE18D95637FAF6989E1BC16FEA
+# uid                 [ unknown] Swift Automatic Signing Key #3 <swift-infrastructure@swift.org>
+ARG SWIFT_SIGNING_KEY=8A7495662C3CD4AE18D95637FAF6989E1BC16FEA
+ARG SWIFT_PLATFORM=centos
+ARG OS_MAJOR_VER=8
+ARG SWIFT_WEBROOT=https://swift.org/builds/development
+
+ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
+    SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    OS_MAJOR_VER=$OS_MAJOR_VER \
+    OS_VER=$SWIFT_PLATFORM$OS_MAJOR_VER \
+    SWIFT_WEBROOT="$SWIFT_WEBROOT/$SWIFT_PLATFORM$OS_MAJOR_VER"
+
+RUN echo "${SWIFT_WEBROOT}/latest-build.yml"
+
+RUN set -e; \
+    # - Latest Toolchain info
+    export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
+    && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \
+    && export DOWNLOAD_DIR=$(echo $download | sed "s/-${OS_VER}.tar.gz//g") \
+    && echo $DOWNLOAD_DIR > .swift_tag \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fsSL ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz \
+    ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download_signature} -o latest_toolchain.tar.gz.sig \
+    && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
+    && gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 ${DOWNLOAD_DIR}-${OS_VER}/usr/lib/swift/linux \
+    && chmod -R o+r /usr/lib/swift \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
+
+RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
+    >> /etc/bashrc; \
+    echo -e " ################################################################\n" \
+    "#\t\t\t\t\t\t\t\t#\n" \
+    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
+    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
+    "#\t\t\t\t\t\t\t\t#\n"  \
+    "################################################################\n" > /etc/motd


### PR DESCRIPTION
motivation: provide lightweight runtime images for centos 8 and amazon linux 2

changes:
* add dockerfiles for 5.2 nd nightlies where we support centos8 and al2