### PR TITLE
Ubuntu 20.04: add `python3-dev` and `python3-distutils`

### DIFF
--- a/swift-ci/master/ubuntu/20.04/Dockerfile
+++ b/swift-ci/master/ubuntu/20.04/Dockerfile
@@ -14,12 +14,14 @@ RUN apt -y update && apt -y install \
   libedit-dev           \
   libicu-dev            \
   libncurses5-dev       \
+  libpython3-dev        \
   libsqlite3-dev        \
   libxml2-dev           \
   ninja-build           \
   pkg-config            \
   python                \
   python-six            \
+  python3-distutils     \
   rsync                 \
   swig                  \
   systemtap-sdt-dev     \


### PR DESCRIPTION
These packages are needed to build Swift successfully with Python 3.