### PR TITLE
ubuntu: add Python 3 version of six

### DIFF
--- a/swift-ci/master/ubuntu/20.04/Dockerfile
+++ b/swift-ci/master/ubuntu/20.04/Dockerfile
@@ -21,6 +21,7 @@ RUN apt -y update && apt -y install \
   pkg-config            \
   python                \
   python-six            \
+  python3-six           \
   python3-distutils     \
   rsync                 \
   swig                  \


### PR DESCRIPTION
The `python-six` package provides the python 2 version, ensure that we
also have the python 3 version by adding `python3-six`.