### PR TITLE
Add glibc-static and gcc-c++ to AL2 CI image

### DIFF
--- a/swift-ci/master/amazon-linux/2/Dockerfile
+++ b/swift-ci/master/amazon-linux/2/Dockerfile
@@ -15,7 +15,9 @@ RUN yum -y install \
   clang            \
   cmake            \
   curl-devel       \
+  gcc-c++          \
   git              \
+  glibc-static     \
   libbsd-devel     \
   libedit-devel    \
   libicu-devel     \


### PR DESCRIPTION
These are required for building with `-static-executable`. gcc-c++ provides `libstdc++.a`