### PR TITLE
Add Dockerfiles for 5.2 nightlies on the new platforms

### DIFF
--- a/nightly-5.2/amazonlinux/2/Dockerfile
+++ b/nightly-5.2/amazonlinux/2/Dockerfile
@@ -1,0 +1,71 @@
+FROM amazonlinux:2
+LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
+LABEL description="Docker Container for the Swift programming language"
+
+RUN yum -y install \
+  binutils \
+  gcc \
+  git \
+  glibc-static \
+  gzip \
+  libbsd \
+  libcurl \
+  libedit \
+  libicu \
+  libsqlite \
+  libstdc++-static \
+  libuuid \
+  libxml2 \
+  tar \
+  tzdata \
+  zlib-devel
+
+# Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little
+
+# gpg --keyid-format LONG -k FAF6989E1BC16FEA
+# pub   rsa4096/FAF6989E1BC16FEA 2019-11-07 [SC] [expires: 2021-11-06]
+#       8A7495662C3CD4AE18D95637FAF6989E1BC16FEA
+# uid                 [ unknown] Swift Automatic Signing Key #3 <swift-infrastructure@swift.org>
+ARG SWIFT_SIGNING_KEY=8A7495662C3CD4AE18D95637FAF6989E1BC16FEA
+ARG SWIFT_PLATFORM=amazonlinux
+ARG OS_MAJOR_VER=2
+ARG SWIFT_WEBROOT=https://swift.org/builds/swift-5.2-branch
+
+ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
+    SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    OS_MAJOR_VER=$OS_MAJOR_VER \
+    OS_VER=$SWIFT_PLATFORM$OS_MAJOR_VER \
+    SWIFT_WEBROOT="$SWIFT_WEBROOT/$SWIFT_PLATFORM$OS_MAJOR_VER"
+
+RUN echo "${SWIFT_WEBROOT}/latest-build.yml"
+
+RUN set -e; \
+    # - Latest Toolchain info
+    export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
+    && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \
+    && export DOWNLOAD_DIR=$(echo $download | sed "s/-${OS_VER}.tar.gz//g") \
+    && echo $DOWNLOAD_DIR > .swift_tag \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fsSL ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz \
+    ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download_signature} -o latest_toolchain.tar.gz.sig \
+    && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
+    && gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
+    && chmod -R o+r /usr/lib/swift \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+
+# Print Installed Swift Version
+RUN swift --version
+
+RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
+    >> /etc/bashrc; \
+    echo -e " ################################################################\n" \
+    "#\t\t\t\t\t\t\t\t#\n" \
+    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
+    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
+    "#\t\t\t\t\t\t\t\t#\n"  \
+    "################################################################\n" > /etc/motd
+
+RUN echo 'source /etc/bashrc' >> /root/.bashrc

--- a/nightly-5.2/amazonlinux/2/slim/Dockerfile
+++ b/nightly-5.2/amazonlinux/2/slim/Dockerfile
@@ -1,0 +1,52 @@
+FROM amazonlinux:2
+LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
+LABEL description="Docker Container for the Swift programming language"
+
+# Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little
+
+# gpg --keyid-format LONG -k FAF6989E1BC16FEA
+# pub   rsa4096/FAF6989E1BC16FEA 2019-11-07 [SC] [expires: 2021-11-06]
+#       8A7495662C3CD4AE18D95637FAF6989E1BC16FEA
+# uid                 [ unknown] Swift Automatic Signing Key #3 <swift-infrastructure@swift.org>
+ARG SWIFT_SIGNING_KEY=8A7495662C3CD4AE18D95637FAF6989E1BC16FEA
+ARG SWIFT_PLATFORM=amazonlinux
+ARG OS_MAJOR_VER=2
+ARG SWIFT_WEBROOT=https://swift.org/builds/swift-5.2-branch
+
+ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
+    SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    OS_MAJOR_VER=$OS_MAJOR_VER \
+    OS_VER=$SWIFT_PLATFORM$OS_MAJOR_VER \
+    SWIFT_WEBROOT="$SWIFT_WEBROOT/$SWIFT_PLATFORM$OS_MAJOR_VER"
+
+RUN echo "${SWIFT_WEBROOT}/latest-build.yml"
+
+RUN set -e; \
+    # - Latest Toolchain info
+    export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
+    && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \
+    && export DOWNLOAD_DIR=$(echo $download | sed "s/-${OS_VER}.tar.gz//g") \
+    && echo $DOWNLOAD_DIR > .swift_tag \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fsSL ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz \
+    ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download_signature} -o latest_toolchain.tar.gz.sig \
+    && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
+    && gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && yum -y install tar gzip \
+    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 ${DOWNLOAD_DIR}-${OS_VER}/usr/lib/swift/linux \
+    && chmod -R o+r /usr/lib/swift \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && yum autoremove -y tar gzip
+
+RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
+    >> /etc/bashrc; \
+    echo -e " ################################################################\n" \
+    "#\t\t\t\t\t\t\t\t#\n" \
+    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
+    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
+    "#\t\t\t\t\t\t\t\t#\n"  \
+    "################################################################\n" > /etc/motd
+
+RUN echo 'source /etc/bashrc' >> /root/.bashrc

--- a/nightly-5.2/centos/7/Dockerfile
+++ b/nightly-5.2/centos/7/Dockerfile
@@ -1,0 +1,68 @@
+FROM centos:7
+LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
+LABEL description="Docker Container for the Swift programming language"
+
+RUN yum install shadow-utils.x86_64 -y \
+  binutils \
+  gcc \
+  git \
+  glibc-static \
+  libbsd-devel \
+  libedit \
+  libedit-devel \
+  libicu-devel \
+  libstdc++-static \
+  pkg-config \
+  python2 \
+  sqlite \
+  zlib-devel
+
+RUN sed -i -e 's/\*__block/\*__libc_block/g' /usr/include/unistd.h
+
+# Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little
+
+# gpg --keyid-format LONG -k FAF6989E1BC16FEA
+# pub   rsa4096/FAF6989E1BC16FEA 2019-11-07 [SC] [expires: 2021-11-06]
+#       8A7495662C3CD4AE18D95637FAF6989E1BC16FEA
+# uid                 [ unknown] Swift Automatic Signing Key #3 <swift-infrastructure@swift.org>
+ARG SWIFT_SIGNING_KEY=8A7495662C3CD4AE18D95637FAF6989E1BC16FEA
+ARG SWIFT_PLATFORM=centos
+ARG OS_MAJOR_VER=7
+ARG SWIFT_WEBROOT=https://swift.org/builds/swift-5.2-branch
+
+ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
+    SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    OS_MAJOR_VER=$OS_MAJOR_VER \
+    OS_VER=$SWIFT_PLATFORM$OS_MAJOR_VER \
+    SWIFT_WEBROOT="$SWIFT_WEBROOT/$SWIFT_PLATFORM$OS_MAJOR_VER"
+
+RUN echo "${SWIFT_WEBROOT}/latest-build.yml"
+
+RUN set -e; \
+    # - Latest Toolchain info
+    export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
+    && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \
+    && export DOWNLOAD_DIR=$(echo $download | sed "s/-${OS_VER}.tar.gz//g") \
+    && echo $DOWNLOAD_DIR > .swift_tag \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fL ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz \
+    ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download_signature} -o latest_toolchain.tar.gz.sig \
+    && curl -fL https://swift.org/keys/all-keys.asc | gpg --import -  \
+    && gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
+    && chmod -R o+r /usr/lib/swift \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
+
+# Print Installed Swift Version
+RUN swift --version
+
+RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
+    >> /etc/bashrc; \
+    echo -e " ################################################################\n" \
+    "#\t\t\t\t\t\t\t\t#\n" \
+    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
+    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
+    "#\t\t\t\t\t\t\t\t#\n"  \
+    "################################################################\n" > /etc/motd

--- a/nightly-5.2/centos/7/slim/Dockerfile
+++ b/nightly-5.2/centos/7/slim/Dockerfile
@@ -1,0 +1,48 @@
+FROM centos:7
+LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
+LABEL description="Docker Container for the Swift programming language"
+
+# Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little
+
+# gpg --keyid-format LONG -k FAF6989E1BC16FEA
+# pub   rsa4096/FAF6989E1BC16FEA 2019-11-07 [SC] [expires: 2021-11-06]
+#       8A7495662C3CD4AE18D95637FAF6989E1BC16FEA
+# uid                 [ unknown] Swift Automatic Signing Key #3 <swift-infrastructure@swift.org>
+ARG SWIFT_SIGNING_KEY=8A7495662C3CD4AE18D95637FAF6989E1BC16FEA
+ARG SWIFT_PLATFORM=centos
+ARG OS_MAJOR_VER=7
+ARG SWIFT_WEBROOT=https://swift.org/builds/swift-5.2-branch
+
+ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
+    SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    OS_MAJOR_VER=$OS_MAJOR_VER \
+    OS_VER=$SWIFT_PLATFORM$OS_MAJOR_VER \
+    SWIFT_WEBROOT="$SWIFT_WEBROOT/$SWIFT_PLATFORM$OS_MAJOR_VER"
+
+RUN echo "${SWIFT_WEBROOT}/latest-build.yml"
+
+RUN set -e; \
+    # - Latest Toolchain info
+    export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
+    && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \
+    && export DOWNLOAD_DIR=$(echo $download | sed "s/-${OS_VER}.tar.gz//g") \
+    && echo $DOWNLOAD_DIR > .swift_tag \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fsSL ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz \
+    ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download_signature} -o latest_toolchain.tar.gz.sig \
+    && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
+    && gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 ${DOWNLOAD_DIR}-${OS_VER}/usr/lib/swift/linux \
+    && chmod -R o+r /usr/lib/swift \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
+
+RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
+    >> /etc/bashrc; \
+    echo -e " ################################################################\n" \
+    "#\t\t\t\t\t\t\t\t#\n" \
+    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
+    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
+    "#\t\t\t\t\t\t\t\t#\n"  \
+    "################################################################\n" > /etc/motd

--- a/nightly-5.2/centos/8/Dockerfile
+++ b/nightly-5.2/centos/8/Dockerfile
@@ -1,0 +1,70 @@
+FROM centos:8
+LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
+LABEL description="Docker Container for the Swift programming language"
+
+RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+
+RUN yum install --enablerepo=PowerTools -y \
+  binutils \
+  gcc \
+  git \
+  glibc-static \
+  libbsd-devel \
+  libedit \
+  libedit-devel \
+  libicu-devel \
+  libstdc++-static \
+  pkg-config \
+  python2 \
+  sqlite \
+  zlib-devel
+
+RUN ln -s /usr/bin/python2 /usr/bin/python
+
+# Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little
+
+# gpg --keyid-format LONG -k FAF6989E1BC16FEA
+# pub   rsa4096/FAF6989E1BC16FEA 2019-11-07 [SC] [expires: 2021-11-06]
+#       8A7495662C3CD4AE18D95637FAF6989E1BC16FEA
+# uid                 [ unknown] Swift Automatic Signing Key #3 <swift-infrastructure@swift.org>
+ARG SWIFT_SIGNING_KEY=8A7495662C3CD4AE18D95637FAF6989E1BC16FEA
+ARG SWIFT_PLATFORM=centos
+ARG OS_MAJOR_VER=8
+ARG SWIFT_WEBROOT=https://swift.org/builds/swift-5.2-branch
+
+ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
+    SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    OS_MAJOR_VER=$OS_MAJOR_VER \
+    OS_VER=$SWIFT_PLATFORM$OS_MAJOR_VER \
+    SWIFT_WEBROOT="$SWIFT_WEBROOT/$SWIFT_PLATFORM$OS_MAJOR_VER"
+
+RUN echo "${SWIFT_WEBROOT}/latest-build.yml"
+
+RUN set -e; \
+    # - Latest Toolchain info
+    export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
+    && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \
+    && export DOWNLOAD_DIR=$(echo $download | sed "s/-${OS_VER}.tar.gz//g") \
+    && echo $DOWNLOAD_DIR > .swift_tag \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fsSL ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz \
+    ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download_signature} -o latest_toolchain.tar.gz.sig \
+    && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
+    && gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
+    && chmod -R o+r /usr/lib/swift \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
+
+# Print Installed Swift Version
+RUN swift --version
+
+RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
+    >> /etc/bashrc; \
+    echo -e " ################################################################\n" \
+    "#\t\t\t\t\t\t\t\t#\n" \
+    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
+    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
+    "#\t\t\t\t\t\t\t\t#\n"  \
+    "################################################################\n" > /etc/motd

--- a/nightly-5.2/centos/8/slim/Dockerfile
+++ b/nightly-5.2/centos/8/slim/Dockerfile
@@ -1,0 +1,48 @@
+FROM centos:8
+LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
+LABEL description="Docker Container for the Swift programming language"
+
+# Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little
+
+# gpg --keyid-format LONG -k FAF6989E1BC16FEA
+# pub   rsa4096/FAF6989E1BC16FEA 2019-11-07 [SC] [expires: 2021-11-06]
+#       8A7495662C3CD4AE18D95637FAF6989E1BC16FEA
+# uid                 [ unknown] Swift Automatic Signing Key #3 <swift-infrastructure@swift.org>
+ARG SWIFT_SIGNING_KEY=8A7495662C3CD4AE18D95637FAF6989E1BC16FEA
+ARG SWIFT_PLATFORM=centos
+ARG OS_MAJOR_VER=8
+ARG SWIFT_WEBROOT=https://swift.org/builds/swift-5.2-branch
+
+ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
+    SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    OS_MAJOR_VER=$OS_MAJOR_VER \
+    OS_VER=$SWIFT_PLATFORM$OS_MAJOR_VER \
+    SWIFT_WEBROOT="$SWIFT_WEBROOT/$SWIFT_PLATFORM$OS_MAJOR_VER"
+
+RUN echo "${SWIFT_WEBROOT}/latest-build.yml"
+
+RUN set -e; \
+    # - Latest Toolchain info
+    export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
+    && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \
+    && export DOWNLOAD_DIR=$(echo $download | sed "s/-${OS_VER}.tar.gz//g") \
+    && echo $DOWNLOAD_DIR > .swift_tag \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fsSL ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz \
+    ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download_signature} -o latest_toolchain.tar.gz.sig \
+    && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
+    && gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 ${DOWNLOAD_DIR}-${OS_VER}/usr/lib/swift/linux \
+    && chmod -R o+r /usr/lib/swift \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
+
+RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
+    >> /etc/bashrc; \
+    echo -e " ################################################################\n" \
+    "#\t\t\t\t\t\t\t\t#\n" \
+    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
+    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
+    "#\t\t\t\t\t\t\t\t#\n"  \
+    "################################################################\n" > /etc/motd

--- a/nightly-5.2/ubuntu/20.04/Dockerfile
+++ b/nightly-5.2/ubuntu/20.04/Dockerfile
@@ -1,0 +1,74 @@
+FROM ubuntu:20.04
+LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
+LABEL description="Docker Container for the Swift programming language"
+
+RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
+    apt-get -q install -y \
+    binutils \
+    git \
+    gnupg2 \
+    libc6-dev \
+    libcurl4 \
+    libedit2 \
+    libgcc-9-dev \
+    libpython2.7 \
+    libsqlite3-0 \
+    libstdc++-9-dev \
+    libxml2 \
+    libz3-dev \
+    pkg-config \
+    tzdata \
+    zlib1g-dev \
+    && rm -r /var/lib/apt/lists/*
+
+# Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little
+
+# gpg --keyid-format LONG -k FAF6989E1BC16FEA
+# pub   rsa4096/FAF6989E1BC16FEA 2019-11-07 [SC] [expires: 2021-11-06]
+#       8A7495662C3CD4AE18D95637FAF6989E1BC16FEA
+# uid                 [ unknown] Swift Automatic Signing Key #3 <swift-infrastructure@swift.org>
+ARG SWIFT_SIGNING_KEY=8A7495662C3CD4AE18D95637FAF6989E1BC16FEA
+ARG SWIFT_PLATFORM=ubuntu
+ARG OS_MAJOR_VER=20
+ARG OS_MIN_VER=04
+ARG SWIFT_WEBROOT=https://swift.org/builds/swift-5.2-branch
+
+ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
+    SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    OS_MAJOR_VER=$OS_MAJOR_VER \
+    OS_MIN_VER=$OS_MIN_VER \
+    OS_VER=$SWIFT_PLATFORM$OS_MAJOR_VER.$OS_MIN_VER \
+    SWIFT_WEBROOT="$SWIFT_WEBROOT/$SWIFT_PLATFORM$OS_MAJOR_VER$OS_MIN_VER"
+
+RUN set -e; \
+    # - Grab curl here so we cache better up above
+    export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    # - Latest Toolchain info
+    && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
+    && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \
+    && export DOWNLOAD_DIR=$(echo $download | sed "s/-${OS_VER}.tar.gz//g") \
+    && echo $DOWNLOAD_DIR > .swift_tag \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fsSL ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz \
+    ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download_signature} -o latest_toolchain.tar.gz.sig \
+    && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
+    && gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
+    && chmod -R o+r /usr/lib/swift \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && apt-get purge --auto-remove -y curl
+
+# Print Installed Swift Version
+RUN swift --version
+
+RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
+    >> /etc/bash.bashrc; \
+    echo " ################################################################\n" \
+    "#\t\t\t\t\t\t\t\t#\n" \
+    "# Swift Nightly Docker Image\t\t\t\t#\n" \
+    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
+    "#\t\t\t\t\t\t\t\t#\n"  \
+    "################################################################\n" > /etc/motd

--- a/nightly-5.2/ubuntu/20.04/slim/Dockerfile
+++ b/nightly-5.2/ubuntu/20.04/slim/Dockerfile
@@ -1,0 +1,59 @@
+FROM ubuntu:20.04
+LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
+LABEL description="Docker Container for the Swift programming language"
+
+RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
+    apt-get -q install -y \
+    libcurl4 \
+    libxml2 \
+    tzdata \
+    && rm -r /var/lib/apt/lists/*
+
+# Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little
+
+# gpg --keyid-format LONG -k FAF6989E1BC16FEA
+# pub   rsa4096/FAF6989E1BC16FEA 2019-11-07 [SC] [expires: 2021-11-06]
+#       8A7495662C3CD4AE18D95637FAF6989E1BC16FEA
+# uid                 [ unknown] Swift Automatic Signing Key #3 <swift-infrastructure@swift.org>
+ARG SWIFT_SIGNING_KEY=8A7495662C3CD4AE18D95637FAF6989E1BC16FEA
+ARG SWIFT_PLATFORM=ubuntu
+ARG OS_MAJOR_VER=20
+ARG OS_MIN_VER=04
+ARG SWIFT_WEBROOT=https://swift.org/builds/swift-5.2-branch
+
+ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
+    SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    OS_MAJOR_VER=$OS_MAJOR_VER \
+    OS_MIN_VER=$OS_MIN_VER \
+    OS_VER=$SWIFT_PLATFORM$OS_MAJOR_VER.$OS_MIN_VER \
+    SWIFT_WEBROOT="$SWIFT_WEBROOT/$SWIFT_PLATFORM$OS_MAJOR_VER$OS_MIN_VER"
+
+RUN set -e; \
+    # - Grab curl and gpg here so we cache better up above
+    export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -q update && apt-get -q install -y curl gnupg && rm -rf /var/lib/apt/lists/* \
+    # - Latest Toolchain info
+    && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
+    && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \
+    && export DOWNLOAD_DIR=$(echo $download | sed "s/-${OS_VER}.tar.gz//g") \
+    && echo $DOWNLOAD_DIR > .swift_tag \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fsSL ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz \
+    ${SWIFT_WEBROOT}/${DOWNLOAD_DIR}/${download_signature} -o latest_toolchain.tar.gz.sig \
+    && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
+    && gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 ${DOWNLOAD_DIR}-${OS_VER}/usr/lib/swift/linux \
+    && chmod -R o+r /usr/lib/swift \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && apt-get purge --auto-remove -y curl gnupg
+
+RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
+    >> /etc/bash.bashrc; \
+    echo " ################################################################\n" \
+    "#\t\t\t\t\t\t\t\t#\n" \
+    "# Swift Nightly Docker Image\t\t\t\t#\n" \
+    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
+    "#\t\t\t\t\t\t\t\t#\n"  \
+    "################################################################\n" > /etc/motd


### PR DESCRIPTION
Adds new `Dockerfile`s for building nightlies on the newly supported Linux platforms for which nightlies of the 5.2 snapshots do not already exist:

##### `swift-5.2-branch`

- Ubuntu 20.04 "Focal" (`swiftlang/swift:nightly-5.2-focal`)
- Ubuntu 20.04 "Focal", slim (`swiftlang/swift:nightly-5.2-focal-slim`)
- CentOS 7 (`swiftlang/swift:nightly-5.2-centos7`)
- CentOS 7, slim (`swiftlang/swift:nightly-5.2-centos7-slim`)
- CentOS 8 (`swiftlang/swift:nightly-5.2-centos8`)
- CentOS 8, slim (`swiftlang/swift:nightly-5.2-centos8-slim`)
- AmazonLinux 2 (`swiftlang/swift:nightly-5.2-amazonlinux2`)
- AmazonLinux 2, slim (`swiftlang/swift:nightly-5.2-amazonlinux2-slim`)
