### PR TITLE
optimization debian package manager tweaks

### DIFF
--- a/3.1/Dockerfile
+++ b/3.1/Dockerfile
@@ -4,7 +4,9 @@ LABEL Description="Docker Container for the Apple's Swift programming language"
 
 # Install related packages and set LLVM 3.8 as the compiler
 RUN apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     make \
     libc6-dev \
     clang-3.8 \

--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -4,7 +4,9 @@ LABEL Description="Docker Container for the Apple's Swift programming language"
 
 # Install related packages and set LLVM 3.8 as the compiler
 RUN apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     make \
     libc6-dev \
     clang-3.8 \

--- a/4.1/Dockerfile
+++ b/4.1/Dockerfile
@@ -4,7 +4,9 @@ LABEL Description="Docker Container for the Apple's Swift programming language"
 
 # Install related packages and set LLVM 3.8 as the compiler
 RUN apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     make \
     libc6-dev \
     clang-3.8 \

--- a/4.2/ubuntu/16.04/Dockerfile
+++ b/4.2/ubuntu/16.04/Dockerfile
@@ -4,7 +4,9 @@ LABEL Description="Docker Container for the Swift programming language"
 
 # Install related packages and set LLVM 3.8 as the compiler
 RUN apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     make \
     libc6-dev \
     clang-3.8 \

--- a/4.2/ubuntu/18.04/Dockerfile
+++ b/4.2/ubuntu/18.04/Dockerfile
@@ -4,7 +4,9 @@ LABEL Description="Docker Container for the Swift programming language"
 
 # Install related packages and set LLVM 3.9 as the compiler
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     make \
     libc6-dev \
     clang-3.9 \

--- a/5.0/ubuntu/16.04/Dockerfile
+++ b/5.0/ubuntu/16.04/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL Description="Docker Container for the Swift programming language"
 
 RUN apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     libatomic1 \
     libbsd0 \
     libcurl3 \
@@ -33,7 +35,7 @@ ENV SWIFT_PLATFORM=$SWIFT_PLATFORM \
 # Download GPG keys, signature and Swift package, then unpack, cleanup and execute permissions for foundation libs
 RUN SWIFT_URL=https://swift.org/builds/$SWIFT_BRANCH/$(echo "$SWIFT_PLATFORM" | tr -d .)/$SWIFT_VERSION/$SWIFT_VERSION-$SWIFT_PLATFORM.tar.gz \
     && apt-get -q update \
-    && apt-get -q install -y curl \
+    && apt-get --no-install-recommends -q install -y curl \
     && curl -fSsL $SWIFT_URL -o swift.tar.gz \
     && curl -fSsL $SWIFT_URL.sig -o swift.tar.gz.sig \
     && apt-get purge -y curl \

--- a/5.0/ubuntu/16.04/slim/Dockerfile
+++ b/5.0/ubuntu/16.04/slim/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL Description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     libatomic1 \
     libbsd0 \
     libcurl3 \
@@ -23,7 +25,7 @@ ENV SWIFT_PLATFORM=$SWIFT_PLATFORM \
 # Download GPG keys, signature and Swift package, then unpack, cleanup and execute permissions for foundation libs
 RUN SWIFT_URL=https://swift.org/builds/$SWIFT_BRANCH/$(echo "$SWIFT_PLATFORM" | tr -d .)/$SWIFT_VERSION/$SWIFT_VERSION-$SWIFT_PLATFORM.tar.gz \
     && apt-get update \
-    && apt-get install -y curl \
+    && apt-get --no-install-recommends install -y curl \
     && curl -fSsL $SWIFT_URL -o swift.tar.gz \
     && curl -fSsL $SWIFT_URL.sig -o swift.tar.gz.sig \
     && export GNUPGHOME="$(mktemp -d)" \

--- a/5.0/ubuntu/18.04/Dockerfile
+++ b/5.0/ubuntu/18.04/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL Description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     libatomic1 \
     libbsd0 \
     libcurl4 \
@@ -33,7 +35,7 @@ ENV SWIFT_PLATFORM=$SWIFT_PLATFORM \
 # Download GPG keys, signature and Swift package, then unpack, cleanup and execute permissions for foundation libs
 RUN SWIFT_URL=https://swift.org/builds/$SWIFT_BRANCH/$(echo "$SWIFT_PLATFORM" | tr -d .)/$SWIFT_VERSION/$SWIFT_VERSION-$SWIFT_PLATFORM.tar.gz \
     && apt-get update \
-    && apt-get install -y curl \
+    && apt-get --no-install-recommends install -y curl \
     && curl -fSsL $SWIFT_URL -o swift.tar.gz \
     && curl -fSsL $SWIFT_URL.sig -o swift.tar.gz.sig \
     && apt-get purge -y curl \

--- a/5.0/ubuntu/18.04/slim/Dockerfile
+++ b/5.0/ubuntu/18.04/slim/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL Description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     libatomic1 \
     libbsd0 \
     libcurl4 \
@@ -23,7 +25,7 @@ ENV SWIFT_PLATFORM=$SWIFT_PLATFORM \
 # Download GPG keys, signature and Swift package, then unpack, cleanup and execute permissions for foundation libs
 RUN SWIFT_URL=https://swift.org/builds/$SWIFT_BRANCH/$(echo "$SWIFT_PLATFORM" | tr -d .)/$SWIFT_VERSION/$SWIFT_VERSION-$SWIFT_PLATFORM.tar.gz \
     && apt-get update \
-    && apt-get install -y curl gpg \
+    && apt-get --no-install-recommends install -y curl gpg \
     && curl -fSsL $SWIFT_URL -o swift.tar.gz \
     && curl -fSsL $SWIFT_URL.sig -o swift.tar.gz.sig \
     && export GNUPGHOME="$(mktemp -d)" \

--- a/5.1/ubuntu/16.04/Dockerfile
+++ b/5.1/ubuntu/16.04/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL Description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     libatomic1 \
     libcurl3 \
     libxml2 \
@@ -43,7 +45,7 @@ RUN set -e; \
     && SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
     # - Grab curl here so we cache better up above
     && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl && rm -rf /var/lib/apt/lists/* \
     # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
     && export GNUPGHOME="$(mktemp -d)" \
     && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \

--- a/5.1/ubuntu/16.04/slim/Dockerfile
+++ b/5.1/ubuntu/16.04/slim/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL Description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     libatomic1 \
     libcurl3 \
     libxml2 \
@@ -33,7 +35,7 @@ RUN set -e; \
     && SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
     # - Grab curl here so we cache better up above
     && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl && rm -rf /var/lib/apt/lists/* \
     # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
     && export GNUPGHOME="$(mktemp -d)" \
     && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \

--- a/5.1/ubuntu/18.04/Dockerfile
+++ b/5.1/ubuntu/18.04/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL Description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     libatomic1 \
     libcurl4 \
     libxml2 \
@@ -43,7 +45,7 @@ RUN set -e; \
     && SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
     # - Grab curl here so we cache better up above
     && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl && rm -rf /var/lib/apt/lists/* \
     # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
     && export GNUPGHOME="$(mktemp -d)" \
     && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \

--- a/5.1/ubuntu/18.04/slim/Dockerfile
+++ b/5.1/ubuntu/18.04/slim/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL Description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     libatomic1 \
     libcurl4 \
     libxml2 \
@@ -33,7 +35,7 @@ RUN set -e; \
     && SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
     # - Grab curl and gpg here so we cache better up above
     && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl gnupg && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl gnupg && rm -rf /var/lib/apt/lists/* \
     # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
     && export GNUPGHOME="$(mktemp -d)" \
     && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \

--- a/5.2/ubuntu/16.04/Dockerfile
+++ b/5.2/ubuntu/16.04/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL Description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     libatomic1 \
     libcurl3 \
     libxml2 \
@@ -43,7 +45,7 @@ RUN set -e; \
     && SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
     # - Grab curl here so we cache better up above
     && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl && rm -rf /var/lib/apt/lists/* \
     # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
     && export GNUPGHOME="$(mktemp -d)" \
     && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \

--- a/5.2/ubuntu/16.04/slim/Dockerfile
+++ b/5.2/ubuntu/16.04/slim/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL Description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     libatomic1 \
     libcurl3 \
     libxml2 \
@@ -33,7 +35,7 @@ RUN set -e; \
     && SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
     # - Grab curl here so we cache better up above
     && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl && rm -rf /var/lib/apt/lists/* \
     # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
     && export GNUPGHOME="$(mktemp -d)" \
     && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \

--- a/5.2/ubuntu/18.04/Dockerfile
+++ b/5.2/ubuntu/18.04/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL Description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     libatomic1 \
     libcurl4 \
     libxml2 \
@@ -43,7 +45,7 @@ RUN set -e; \
     && SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
     # - Grab curl here so we cache better up above
     && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl && rm -rf /var/lib/apt/lists/* \
     # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
     && export GNUPGHOME="$(mktemp -d)" \
     && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \

--- a/5.2/ubuntu/18.04/slim/Dockerfile
+++ b/5.2/ubuntu/18.04/slim/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL Description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     libatomic1 \
     libcurl4 \
     libxml2 \
@@ -33,7 +35,7 @@ RUN set -e; \
     && SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
     # - Grab curl and gpg here so we cache better up above
     && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl gnupg && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl gnupg && rm -rf /var/lib/apt/lists/* \
     # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
     && export GNUPGHOME="$(mktemp -d)" \
     && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \

--- a/5.2/ubuntu/20.04/Dockerfile
+++ b/5.2/ubuntu/20.04/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     binutils \
     git \
     gnupg2 \
@@ -44,7 +46,7 @@ RUN set -e; \
     && SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
     # - Grab curl here so we cache better up above
     && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl && rm -rf /var/lib/apt/lists/* \
     # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
     && export GNUPGHOME="$(mktemp -d)" \
     && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \

--- a/5.2/ubuntu/20.04/slim/Dockerfile
+++ b/5.2/ubuntu/20.04/slim/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     libcurl4 \
     libxml2 \
     tzdata \
@@ -32,7 +34,7 @@ RUN set -e; \
     && SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
     # - Grab curl and gpg here so we cache better up above
     && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl gnupg && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl gnupg && rm -rf /var/lib/apt/lists/* \
     # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
     && export GNUPGHOME="$(mktemp -d)" \
     && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \

--- a/5.3/ubuntu/16.04/Dockerfile
+++ b/5.3/ubuntu/16.04/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL Description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     libatomic1 \
     libcurl3 \
     libxml2 \
@@ -43,7 +45,7 @@ RUN set -e; \
     && SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
     # - Grab curl here so we cache better up above
     && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl && rm -rf /var/lib/apt/lists/* \
     # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
     && export GNUPGHOME="$(mktemp -d)" \
     && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \

--- a/5.3/ubuntu/16.04/slim/Dockerfile
+++ b/5.3/ubuntu/16.04/slim/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL Description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     libatomic1 \
     libcurl3 \
     libxml2 \
@@ -33,7 +35,7 @@ RUN set -e; \
     && SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
     # - Grab curl here so we cache better up above
     && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl && rm -rf /var/lib/apt/lists/* \
     # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
     && export GNUPGHOME="$(mktemp -d)" \
     && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \

--- a/5.3/ubuntu/18.04/Dockerfile
+++ b/5.3/ubuntu/18.04/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL Description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     libatomic1 \
     libcurl4 \
     libxml2 \
@@ -43,7 +45,7 @@ RUN set -e; \
     && SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
     # - Grab curl here so we cache better up above
     && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl && rm -rf /var/lib/apt/lists/* \
     # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
     && export GNUPGHOME="$(mktemp -d)" \
     && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \

--- a/5.3/ubuntu/18.04/slim/Dockerfile
+++ b/5.3/ubuntu/18.04/slim/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL Description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     libatomic1 \
     libcurl4 \
     libxml2 \
@@ -33,7 +35,7 @@ RUN set -e; \
     && SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
     # - Grab curl and gpg here so we cache better up above
     && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl gnupg && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl gnupg && rm -rf /var/lib/apt/lists/* \
     # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
     && export GNUPGHOME="$(mktemp -d)" \
     && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \

--- a/5.3/ubuntu/20.04/Dockerfile
+++ b/5.3/ubuntu/20.04/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     binutils \
     git \
     gnupg2 \
@@ -44,7 +46,7 @@ RUN set -e; \
     && SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
     # - Grab curl here so we cache better up above
     && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl && rm -rf /var/lib/apt/lists/* \
     # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
     && export GNUPGHOME="$(mktemp -d)" \
     && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \

--- a/5.3/ubuntu/20.04/slim/Dockerfile
+++ b/5.3/ubuntu/20.04/slim/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     libcurl4 \
     libxml2 \
     tzdata \
@@ -32,7 +34,7 @@ RUN set -e; \
     && SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
     # - Grab curl and gpg here so we cache better up above
     && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl gnupg && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl gnupg && rm -rf /var/lib/apt/lists/* \
     # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
     && export GNUPGHOME="$(mktemp -d)" \
     && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \

--- a/nightly-5.2/ubuntu/16.04/Dockerfile
+++ b/nightly-5.2/ubuntu/16.04/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     libatomic1 \
     libcurl3 \
     libxml2 \
@@ -42,7 +44,7 @@ ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
 RUN set -e; \
     # - Grab curl here so we cache better up above
     export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl && rm -rf /var/lib/apt/lists/* \
     # - Latest Toolchain info
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \

--- a/nightly-5.2/ubuntu/16.04/slim/Dockerfile
+++ b/nightly-5.2/ubuntu/16.04/slim/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     libatomic1 \
     libcurl3 \
     libxml2 \
@@ -32,7 +34,7 @@ ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
 RUN set -e; \
     # - Grab curl and gpg here so we cache better up above
     export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl && rm -rf /var/lib/apt/lists/* \
     # - Latest Toolchain info
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \

--- a/nightly-5.2/ubuntu/18.04/Dockerfile
+++ b/nightly-5.2/ubuntu/18.04/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     libatomic1 \
     libcurl4 \
     libxml2 \
@@ -42,7 +44,7 @@ ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
 RUN set -e; \
     # - Grab curl here so we cache better up above
     export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl && rm -rf /var/lib/apt/lists/* \
     # - Latest Toolchain info
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \

--- a/nightly-5.2/ubuntu/18.04/slim/Dockerfile
+++ b/nightly-5.2/ubuntu/18.04/slim/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     libatomic1 \
     libcurl4 \
     libxml2 \
@@ -32,7 +34,7 @@ ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
 RUN set -e; \
     # - Grab curl and gpg here so we cache better up above
     export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl gnupg && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl gnupg && rm -rf /var/lib/apt/lists/* \
     # - Latest Toolchain info
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \

--- a/nightly-5.3/ubuntu/16.04/Dockerfile
+++ b/nightly-5.3/ubuntu/16.04/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     libatomic1 \
     libcurl3 \
     libxml2 \
@@ -42,7 +44,7 @@ ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
 RUN set -e; \
     # - Grab curl here so we cache better up above
     export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl && rm -rf /var/lib/apt/lists/* \
     # - Latest Toolchain info
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \

--- a/nightly-5.3/ubuntu/16.04/slim/Dockerfile
+++ b/nightly-5.3/ubuntu/16.04/slim/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     libatomic1 \
     libcurl3 \
     libxml2 \
@@ -32,7 +34,7 @@ ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
 RUN set -e; \
     # - Grab curl and gpg here so we cache better up above
     export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl && rm -rf /var/lib/apt/lists/* \
     # - Latest Toolchain info
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \

--- a/nightly-5.3/ubuntu/18.04/Dockerfile
+++ b/nightly-5.3/ubuntu/18.04/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     libatomic1 \
     libcurl4 \
     libxml2 \
@@ -42,7 +44,7 @@ ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
 RUN set -e; \
     # - Grab curl here so we cache better up above
     export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl && rm -rf /var/lib/apt/lists/* \
     # - Latest Toolchain info
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \

--- a/nightly-5.3/ubuntu/18.04/slim/Dockerfile
+++ b/nightly-5.3/ubuntu/18.04/slim/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     libatomic1 \
     libcurl4 \
     libxml2 \
@@ -32,7 +34,7 @@ ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
 RUN set -e; \
     # - Grab curl and gpg here so we cache better up above
     export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl gnupg && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl gnupg && rm -rf /var/lib/apt/lists/* \
     # - Latest Toolchain info
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \

--- a/nightly-5.3/ubuntu/20.04/Dockerfile
+++ b/nightly-5.3/ubuntu/20.04/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     binutils \
     git \
     gnupg2 \
@@ -43,7 +45,7 @@ ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
 RUN set -e; \
     # - Grab curl here so we cache better up above
     export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl && rm -rf /var/lib/apt/lists/* \
     # - Latest Toolchain info
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \

--- a/nightly-5.3/ubuntu/20.04/slim/Dockerfile
+++ b/nightly-5.3/ubuntu/20.04/slim/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     libcurl4 \
     libxml2 \
     tzdata \
@@ -31,7 +33,7 @@ ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
 RUN set -e; \
     # - Grab curl and gpg here so we cache better up above
     export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl gnupg && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl gnupg && rm -rf /var/lib/apt/lists/* \
     # - Latest Toolchain info
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \

--- a/nightly-master/ubuntu/16.04/Dockerfile
+++ b/nightly-master/ubuntu/16.04/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     binutils \
     git \
     libc6-dev \
@@ -41,7 +43,7 @@ ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
 RUN set -e; \
     # - Grab curl here so we cache better up above
     export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl && rm -rf /var/lib/apt/lists/* \
     # - Latest Toolchain info
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \

--- a/nightly-master/ubuntu/16.04/slim/Dockerfile
+++ b/nightly-master/ubuntu/16.04/slim/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     libcurl3 \
     libxml2 \
     tzdata \
@@ -31,7 +33,7 @@ ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
 RUN set -e; \
     # - Grab curl and gpg here so we cache better up above
     export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl && rm -rf /var/lib/apt/lists/* \
     # - Latest Toolchain info
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \

--- a/nightly-master/ubuntu/18.04/Dockerfile
+++ b/nightly-master/ubuntu/18.04/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     binutils \
     git \
     libc6-dev \
@@ -41,7 +43,7 @@ ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
 RUN set -e; \
     # - Grab curl here so we cache better up above
     export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl && rm -rf /var/lib/apt/lists/* \
     # - Latest Toolchain info
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \

--- a/nightly-master/ubuntu/18.04/slim/Dockerfile
+++ b/nightly-master/ubuntu/18.04/slim/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     libcurl4 \
     libxml2 \
     tzdata \
@@ -31,7 +33,7 @@ ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
 RUN set -e; \
     # - Grab curl and gpg here so we cache better up above
     export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl gnupg && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl gnupg && rm -rf /var/lib/apt/lists/* \
     # - Latest Toolchain info
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \

--- a/nightly-master/ubuntu/20.04/Dockerfile
+++ b/nightly-master/ubuntu/20.04/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     binutils \
     git \
     gnupg2 \
@@ -45,7 +47,7 @@ RUN echo "${SWIFT_WEBROOT}/latest-build.yml"
 RUN set -e; \
     # - Grab curl here so we cache better up above
     export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl && rm -rf /var/lib/apt/lists/* \
     # - Latest Toolchain info
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \

--- a/nightly-master/ubuntu/20.04/slim/Dockerfile
+++ b/nightly-master/ubuntu/20.04/slim/Dockerfile
@@ -3,7 +3,9 @@ LABEL maintainer="Swift Infrastructure <swift-infrastructure@swift.org>"
 LABEL description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
-    apt-get -q install -y \
+    apt-get --no-install-recommends install -y \
+    apt-utils \
+    ca-certificates \
     libcurl4 \
     libxml2 \
     tzdata \
@@ -31,7 +33,7 @@ ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
 RUN set -e; \
     # - Grab curl and gpg here so we cache better up above
     export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl gnupg && rm -rf /var/lib/apt/lists/* \
+    && apt-get -q update && apt-get --no-install-recommends -q install -y curl gnupg && rm -rf /var/lib/apt/lists/* \
     # - Latest Toolchain info
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Also , added packages apt-utils ca-certificates

Because build is

1.  Slow because "apt-utils" not installed

2. to avoid build to exits with error without having certificate in wget , curl or even git clone

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>