### PR TITLE
Fixed missing -lcurl when building with -static-stdlib and FoundationNetworking.

### DIFF
--- a/nightly-5.3/ubuntu/18.04/Dockerfile
+++ b/nightly-5.3/ubuntu/18.04/Dockerfile
@@ -6,6 +6,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     apt-get -q install -y \
     libatomic1 \
     libcurl4 \
+    libcurl4-openssl-dev \
     libxml2 \
     libedit2 \
     libsqlite3-0 \


### PR DESCRIPTION
`swift:nightly` now allows building standalone/statically linked executables with something like

```
swift build -Xswiftc -static-stdlib
```

However, if you import FoundationNetworking in your sources, that makes you add more libraries explicitly for linking to resolve the missing symbols:

```
swift build -Xswiftc -static-stdlib -Xlinker -lCoreFoundation -Xlinker -lCFURLSessionInterface -Xlinker -lcurl
```

and yet that is not enough, because it can not resolve `-lcurl` that is probably originating from https://github.com/apple/swift-corelibs-foundation/blob/76068b8caf54f250a7be5336a7c6bb97f55469f8/CoreFoundation/URL.subproj/static/module.map

It manifests as something like below (I quote just a part of long list of missing `curl_` family of functions):

```
/usr/lib/swift_static/linux/libCFURLSessionInterface.a(CFURLSessionInterface.c.o):CFURLSessionInterface.c:function CFURLSessionEasyCodeDescription: error: undefined reference to 'curl_easy_strerror'
/usr/lib/swift_static/linux/libCFURLSessionInterface.a(CFURLSessionInterface.c.o):CFURLSessionInterface.c:function CFURLSessionEasyHandleInit: error: undefined reference to 'curl_easy_init'
```

This PR solves it by adding dev package for libcurl (libcurl4-openssl-dev, containing static variant of the library) into the image.

I'm not sure about the flavor though given that there're three variants for Ubuntu:
```
libcurl4-gnutls-dev - development files and documentation for libcurl (GnuTLS flavour)
libcurl4-nss-dev - development files and documentation for libcurl (NSS flavour)
libcurl4-openssl-dev - development files and documentation for libcurl (OpenSSL flavour)
```