### PR TITLE
Fixed missing -lcurl when building with -static-stdlib and FoundationNetworking

### DIFF
--- a/nightly-master/ubuntu/18.04/Dockerfile
+++ b/nightly-master/ubuntu/18.04/Dockerfile
@@ -8,6 +8,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     git \
     libc6-dev \
     libcurl4 \
+    libcurl4-openssl-dev \
     libedit2 \
     libgcc-5-dev \
     libpython2.7 \


### PR DESCRIPTION
`swift:nightly` now allows building standalone/statically linked executables with something like

```
swift build -Xswiftc -static-stdlib
```

However, if you import FoundationNetworking in your sources, that makes you add more libraries explicitly for linking to resolve the missing symbols:

```
swift build -Xswiftc -static-stdlib -Xlinker -lCoreFoundation -Xlinker -lCFURLSessionInterface -Xlinker -lcurl
```

and yet that is not enough, because it can not resolve `-lcurl` that is probably originating from https://github.com/apple/swift-corelibs-foundation/blob/76068b8caf54f250a7be5336a7c6bb97f55469f8/CoreFoundation/URL.subproj/static/module.map

It manifests as something like below (I quote just a part of long list of missing `curl_` family of functions):

```
/usr/lib/swift_static/linux/libCFURLSessionInterface.a(CFURLSessionInterface.c.o):CFURLSessionInterface.c:function CFURLSessionEasyCodeDescription: error: undefined reference to 'curl_easy_strerror'
/usr/lib/swift_static/linux/libCFURLSessionInterface.a(CFURLSessionInterface.c.o):CFURLSessionInterface.c:function CFURLSessionEasyHandleInit: error: undefined reference to 'curl_easy_init'
```

This PR solves it by adding dev package for libcurl (libcurl4-openssl-dev, containing static variant of the library) into the image.

I'm not sure about the flavor though given that there're three variants for Ubuntu:
```
libcurl4-gnutls-dev - development files and documentation for libcurl (GnuTLS flavour)
libcurl4-nss-dev - development files and documentation for libcurl (NSS flavour)
libcurl4-openssl-dev - development files and documentation for libcurl (OpenSSL flavour)
```

P.S. You can take a look at the sample reproducing the problem here: https://github.com/grigorye/SwiftDockerLCURLSample

To reproduce the problem, clone the repo and do `docker build .`:

```
$ docker build .
Sending build context to Docker daemon  199.3MB
Step 1/4 : FROM swiftlang/swift:nightly as builder
 ---> fd130a50695f
Step 2/4 : WORKDIR /root
 ---> Using cache
 ---> d67c89c35784
Step 3/4 : COPY . .
 ---> e47e6839c5f6
Step 4/4 : RUN swift build -c release -Xswiftc -static-stdlib -Xlinker -lCoreFoundation -Xlinker -lCFURLSessionInterface     && ldd .build/release/SwiftDockerLCURLSample
 ---> Running in 3f711c218957
[1/2] Compiling SwiftDockerLCURLSample main.swift
/usr/bin/ld.gold: error: cannot find -lcurl
/usr/lib/swift_static/linux/libFoundation.a(NSPathUtilities.swift.o):NSPathUtilities.swift.o:function $s10Foundation22_NSCreateTemporaryFileys5Int32V_SStSSKF: warning: the use of `mktemp' is dangerous, better use `mkstemp' or `mkdtemp'
/usr/lib/swift_static/linux/libCFURLSessionInterface.a(CFURLSessionInterface.c.o):CFURLSessionInterface.c:function CFURLSessionEasyCodeDescription: error: undefined reference to 'curl_easy_strerror'
/usr/lib/swift_static/linux/libCFURLSessionInterface.a(CFURLSessionInterface.c.o):CFURLSessionInterface.c:function CFURLSessionEasyHandleInit: error: undefined reference to 'curl_easy_init'
/usr/lib/swift_static/linux/libCFURLSessionInterface.a(CFURLSessionInterface.c.o):CFURLSessionInterface.c:function CFURLSessionEasyHandleDeinit: error: undefined reference to 'curl_easy_cleanup'
/usr/lib/swift_static/linux/libCFURLSessionInterface.a(CFURLSessionInterface.c.o):CFURLSessionInterface.c:function CFURLSessionEasyHandleSetPauseState: error: undefined reference to 'curl_easy_pause'
/usr/lib/swift_static/linux/libCFURLSessionInterface.a(CFURLSessionInterface.c.o):CFURLSessionInterface.c:function CFURLSessionMultiHandleInit: error: undefined reference to 'curl_multi_init'
/usr/lib/swift_static/linux/libCFURLSessionInterface.a(CFURLSessionInterface.c.o):CFURLSessionInterface.c:function CFURLSessionMultiHandleDeinit: error: undefined reference to 'curl_multi_cleanup'
/usr/lib/swift_static/linux/libCFURLSessionInterface.a(CFURLSessionInterface.c.o):CFURLSessionInterface.c:function CFURLSessionMultiHandleAddHandle: error: undefined reference to 'curl_multi_add_handle'
/usr/lib/swift_static/linux/libCFURLSessionInterface.a(CFURLSessionInterface.c.o):CFURLSessionInterface.c:function CFURLSessionMultiHandleRemoveHandle: error: undefined reference to 'curl_multi_remove_handle'
/usr/lib/swift_static/linux/libCFURLSessionInterface.a(CFURLSessionInterface.c.o):CFURLSessionInterface.c:function CFURLSessionMultiHandleAssign: error: undefined reference to 'curl_multi_assign'
/usr/lib/swift_static/linux/libCFURLSessionInterface.a(CFURLSessionInterface.c.o):CFURLSessionInterface.c:function CFURLSessionMultiHandleAction: error: undefined reference to 'curl_multi_socket_action'
/usr/lib/swift_static/linux/libCFURLSessionInterface.a(CFURLSessionInterface.c.o):CFURLSessionInterface.c:function CFURLSessionMultiHandleInfoRead: error: undefined reference to 'curl_multi_info_read'
/usr/lib/swift_static/linux/libCFURLSessionInterface.a(CFURLSessionInterface.c.o):CFURLSessionInterface.c:function CFURLSession_easy_setopt_ptr: error: undefined reference to 'curl_easy_setopt'
/usr/lib/swift_static/linux/libCFURLSessionInterface.a(CFURLSessionInterface.c.o):CFURLSessionInterface.c:function CFURLSession_easy_setopt_int: error: undefined reference to 'curl_easy_setopt'
/usr/lib/swift_static/linux/libCFURLSessionInterface.a(CFURLSessionInterface.c.o):CFURLSessionInterface.c:function CFURLSession_easy_setopt_long: error: undefined reference to 'curl_easy_setopt'
/usr/lib/swift_static/linux/libCFURLSessionInterface.a(CFURLSessionInterface.c.o):CFURLSessionInterface.c:function CFURLSession_easy_setopt_int64: error: undefined reference to 'curl_easy_setopt'
/usr/lib/swift_static/linux/libCFURLSessionInterface.a(CFURLSessionInterface.c.o):CFURLSessionInterface.c:function CFURLSession_easy_getinfo_long: error: undefined reference to 'curl_easy_getinfo'
/usr/lib/swift_static/linux/libCFURLSessionInterface.a(CFURLSessionInterface.c.o):CFURLSessionInterface.c:function CFURLSession_easy_getinfo_double: error: undefined reference to 'curl_easy_getinfo'
/usr/lib/swift_static/linux/libCFURLSessionInterface.a(CFURLSessionInterface.c.o):CFURLSessionInterface.c:function CFURLSession_easy_getinfo_charp: error: undefined reference to 'curl_easy_getinfo'
/usr/lib/swift_static/linux/libCFURLSessionInterface.a(CFURLSessionInterface.c.o):CFURLSessionInterface.c:function CFURLSession_multi_setopt_ptr: error: undefined reference to 'curl_multi_setopt'
/usr/lib/swift_static/linux/libCFURLSessionInterface.a(CFURLSessionInterface.c.o):CFURLSessionInterface.c:function CFURLSession_multi_setopt_l: error: undefined reference to 'curl_multi_setopt'
/usr/lib/swift_static/linux/libCFURLSessionInterface.a(CFURLSessionInterface.c.o):CFURLSessionInterface.c:function CFURLSession_multi_setopt_sf: error: undefined reference to 'curl_multi_setopt'
/usr/lib/swift_static/linux/libCFURLSessionInterface.a(CFURLSessionInterface.c.o):CFURLSessionInterface.c:function CFURLSession_multi_setopt_tf: error: undefined reference to 'curl_multi_setopt'
/usr/lib/swift_static/linux/libCFURLSessionInterface.a(CFURLSessionInterface.c.o):CFURLSessionInterface.c:function CFURLSessionInit: error: undefined reference to 'curl_global_init'
/usr/lib/swift_static/linux/libCFURLSessionInterface.a(CFURLSessionInterface.c.o):CFURLSessionInterface.c:function CFURLSessionCurlVersionString: error: undefined reference to 'curl_version'
/usr/lib/swift_static/linux/libCFURLSessionInterface.a(CFURLSessionInterface.c.o):CFURLSessionInterface.c:function CFURLSessionCurlVersionInfo: error: undefined reference to 'curl_version_info'
/usr/lib/swift_static/linux/libCFURLSessionInterface.a(CFURLSessionInterface.c.o):CFURLSessionInterface.c:function CFURLSessionSListAppend: error: undefined reference to 'curl_slist_append'
/usr/lib/swift_static/linux/libCFURLSessionInterface.a(CFURLSessionInterface.c.o):CFURLSessionInterface.c:function CFURLSessionSListFreeAll: error: undefined reference to 'curl_slist_free_all'
clang-10: error: linker command failed with exit code 1 (use -v to see invocation)
<unknown>:0: error: link command failed with exit code 1 (use -v to see invocation)
[1/2] Linking SwiftDockerLCURLSample
The command '/bin/sh -c swift build -c release -Xswiftc -static-stdlib -Xlinker -lCoreFoundation -Xlinker -lCFURLSessionInterface     && ldd .build/release/SwiftDockerLCURLSample' returned a non-zero code: 1
```