### PR TITLE
Include GNU Make for swift:5.3-focal

### DIFF
--- a/5.3/ubuntu/20.04/Dockerfile
+++ b/5.3/ubuntu/20.04/Dockerfile
@@ -16,6 +16,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     libstdc++-9-dev \
     libxml2 \
     libz3-dev \
+    make \
     pkg-config \
     tzdata \
     zlib1g-dev \


### PR DESCRIPTION
It is very convenient to have GNU Make preinstalled in the image, as was the case with the 18.04 images.