### PR TITLE
Update 5.3 release Dockerfiles for the Swift 5.3.1 release

### DIFF
--- a/5.3/amazonlinux/2/Dockerfile
+++ b/5.3/amazonlinux/2/Dockerfile
@@ -27,8 +27,8 @@ RUN yum -y install \
 # uid                  Swift 5.x Release Signing Key <swift-infrastructure@swift.org
 ARG SWIFT_SIGNING_KEY=A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
 ARG SWIFT_PLATFORM=amazonlinux2
-ARG SWIFT_BRANCH=swift-5.3-release
-ARG SWIFT_VERSION=swift-5.3-RELEASE
+ARG SWIFT_BRANCH=swift-5.3.1-release
+ARG SWIFT_VERSION=swift-5.3.1-RELEASE
 ARG SWIFT_WEBROOT=https://swift.org/builds/
 
 ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \

--- a/5.3/amazonlinux/2/slim/Dockerfile
+++ b/5.3/amazonlinux/2/slim/Dockerfile
@@ -9,8 +9,8 @@ LABEL description="Docker Container for the Swift programming language"
 # uid                  Swift 5.x Release Signing Key <swift-infrastructure@swift.org
 ARG SWIFT_SIGNING_KEY=A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
 ARG SWIFT_PLATFORM=amazonlinux2
-ARG SWIFT_BRANCH=swift-5.3-release
-ARG SWIFT_VERSION=swift-5.3-RELEASE
+ARG SWIFT_BRANCH=swift-5.3.1-release
+ARG SWIFT_VERSION=swift-5.3.1-RELEASE
 ARG SWIFT_WEBROOT=https://swift.org/builds/
 
 ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \

--- a/5.3/centos/7/Dockerfile
+++ b/5.3/centos/7/Dockerfile
@@ -26,8 +26,8 @@ RUN sed -i -e 's/\*__block/\*__libc_block/g' /usr/include/unistd.h
 # uid                  Swift 5.x Release Signing Key <swift-infrastructure@swift.org
 ARG SWIFT_SIGNING_KEY=A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
 ARG SWIFT_PLATFORM=centos7
-ARG SWIFT_BRANCH=swift-5.3-release
-ARG SWIFT_VERSION=swift-5.3-RELEASE
+ARG SWIFT_BRANCH=swift-5.3.1-release
+ARG SWIFT_VERSION=swift-5.3.1-RELEASE
 ARG SWIFT_WEBROOT=https://swift.org/builds/
 
 ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \

--- a/5.3/centos/7/slim/Dockerfile
+++ b/5.3/centos/7/slim/Dockerfile
@@ -9,8 +9,8 @@ LABEL description="Docker Container for the Swift programming language"
 # uid                  Swift 5.x Release Signing Key <swift-infrastructure@swift.org
 ARG SWIFT_SIGNING_KEY=A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
 ARG SWIFT_PLATFORM=centos7
-ARG SWIFT_BRANCH=swift-5.3-release
-ARG SWIFT_VERSION=swift-5.3-RELEASE
+ARG SWIFT_BRANCH=swift-5.3.1-release
+ARG SWIFT_VERSION=swift-5.3.1-RELEASE
 ARG SWIFT_WEBROOT=https://swift.org/builds/
 
 ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \

--- a/5.3/centos/8/Dockerfile
+++ b/5.3/centos/8/Dockerfile
@@ -28,8 +28,8 @@ RUN ln -s /usr/bin/python2 /usr/bin/python
 # uid                  Swift 5.x Release Signing Key <swift-infrastructure@swift.org
 ARG SWIFT_SIGNING_KEY=A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
 ARG SWIFT_PLATFORM=centos8
-ARG SWIFT_BRANCH=swift-5.3-release
-ARG SWIFT_VERSION=swift-5.3-RELEASE
+ARG SWIFT_BRANCH=swift-5.3.1-release
+ARG SWIFT_VERSION=swift-5.3.1-RELEASE
 ARG SWIFT_WEBROOT=https://swift.org/builds/
 
 ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \

--- a/5.3/centos/8/slim/Dockerfile
+++ b/5.3/centos/8/slim/Dockerfile
@@ -9,8 +9,8 @@ LABEL description="Docker Container for the Swift programming language"
 # uid                  Swift 5.x Release Signing Key <swift-infrastructure@swift.org
 ARG SWIFT_SIGNING_KEY=A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
 ARG SWIFT_PLATFORM=centos8
-ARG SWIFT_BRANCH=swift-5.3-release
-ARG SWIFT_VERSION=swift-5.3-RELEASE
+ARG SWIFT_BRANCH=swift-5.3.1-release
+ARG SWIFT_VERSION=swift-5.3.1-RELEASE
 ARG SWIFT_WEBROOT=https://swift.org/builds/
 
 ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \

--- a/5.3/ubuntu/16.04/Dockerfile
+++ b/5.3/ubuntu/16.04/Dockerfile
@@ -27,8 +27,8 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
 # uid                  Swift 5.x Release Signing Key <swift-infrastructure@swift.org
 ARG SWIFT_SIGNING_KEY=A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
 ARG SWIFT_PLATFORM=ubuntu16.04
-ARG SWIFT_BRANCH=swift-5.3-release
-ARG SWIFT_VERSION=swift-5.3-RELEASE
+ARG SWIFT_BRANCH=swift-5.3.1-release
+ARG SWIFT_VERSION=swift-5.3.1-RELEASE
 ARG SWIFT_WEBROOT=https://swift.org/builds/
 
 ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \

--- a/5.3/ubuntu/16.04/slim/Dockerfile
+++ b/5.3/ubuntu/16.04/slim/Dockerfile
@@ -17,8 +17,8 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
 # uid                  Swift 5.x Release Signing Key <swift-infrastructure@swift.org
 ARG SWIFT_SIGNING_KEY=A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
 ARG SWIFT_PLATFORM=ubuntu16.04
-ARG SWIFT_BRANCH=swift-5.3-release
-ARG SWIFT_VERSION=swift-5.3-RELEASE
+ARG SWIFT_BRANCH=swift-5.3.1-release
+ARG SWIFT_VERSION=swift-5.3.1-RELEASE
 ARG SWIFT_WEBROOT=https://swift.org/builds/
 
 ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \

--- a/5.3/ubuntu/18.04/Dockerfile
+++ b/5.3/ubuntu/18.04/Dockerfile
@@ -27,8 +27,8 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
 # uid                  Swift 5.x Release Signing Key <swift-infrastructure@swift.org
 ARG SWIFT_SIGNING_KEY=A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
 ARG SWIFT_PLATFORM=ubuntu18.04
-ARG SWIFT_BRANCH=swift-5.3-release
-ARG SWIFT_VERSION=swift-5.3-RELEASE
+ARG SWIFT_BRANCH=swift-5.3.1-release
+ARG SWIFT_VERSION=swift-5.3.1-RELEASE
 ARG SWIFT_WEBROOT=https://swift.org/builds/
 
 ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \

--- a/5.3/ubuntu/18.04/slim/Dockerfile
+++ b/5.3/ubuntu/18.04/slim/Dockerfile
@@ -17,8 +17,8 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
 # uid                  Swift 5.x Release Signing Key <swift-infrastructure@swift.org
 ARG SWIFT_SIGNING_KEY=A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
 ARG SWIFT_PLATFORM=ubuntu18.04
-ARG SWIFT_BRANCH=swift-5.3-release
-ARG SWIFT_VERSION=swift-5.3-RELEASE
+ARG SWIFT_BRANCH=swift-5.3.1-release
+ARG SWIFT_VERSION=swift-5.3.1-RELEASE
 ARG SWIFT_WEBROOT=https://swift.org/builds/
 
 ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \

--- a/5.3/ubuntu/20.04/Dockerfile
+++ b/5.3/ubuntu/20.04/Dockerfile
@@ -28,8 +28,8 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
 # uid                  Swift 5.x Release Signing Key <swift-infrastructure@swift.org
 ARG SWIFT_SIGNING_KEY=A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
 ARG SWIFT_PLATFORM=ubuntu20.04
-ARG SWIFT_BRANCH=swift-5.3-release
-ARG SWIFT_VERSION=swift-5.3-RELEASE
+ARG SWIFT_BRANCH=swift-5.3.1-release
+ARG SWIFT_VERSION=swift-5.3.1-RELEASE
 ARG SWIFT_WEBROOT=https://swift.org/builds/
 
 ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \

--- a/5.3/ubuntu/20.04/slim/Dockerfile
+++ b/5.3/ubuntu/20.04/slim/Dockerfile
@@ -16,8 +16,8 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
 # uid                  Swift 5.x Release Signing Key <swift-infrastructure@swift.org
 ARG SWIFT_SIGNING_KEY=A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
 ARG SWIFT_PLATFORM=ubuntu20.04
-ARG SWIFT_BRANCH=swift-5.3-release
-ARG SWIFT_VERSION=swift-5.3-RELEASE
+ARG SWIFT_BRANCH=swift-5.3.1-release
+ARG SWIFT_VERSION=swift-5.3.1-RELEASE
 ARG SWIFT_WEBROOT=https://swift.org/builds/
 
 ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \


### PR DESCRIPTION
Very straightforward - just replaces 5.3 with 5.3.1 in the appropriate `Dockerfile`s.