### PR TITLE
lldb now requires python 3.6

### DIFF
--- a/nightly-main/ubuntu/16.04/Dockerfile
+++ b/nightly-main/ubuntu/16.04/Dockerfile
@@ -10,7 +10,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     libcurl3 \
     libedit2 \
     libgcc-5-dev \
-    libpython2.7 \
+    libpython3.6 \
     libsqlite3-0 \
     libstdc++-5-dev \
     libxml2 \

--- a/nightly-main/ubuntu/18.04/Dockerfile
+++ b/nightly-main/ubuntu/18.04/Dockerfile
@@ -10,7 +10,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     libcurl4 \
     libedit2 \
     libgcc-5-dev \
-    libpython2.7 \
+    libpython3.6 \
     libsqlite3-0 \
     libstdc++-5-dev \
     libxml2 \

--- a/nightly-main/ubuntu/20.04/Dockerfile
+++ b/nightly-main/ubuntu/20.04/Dockerfile
@@ -11,7 +11,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     libcurl4 \
     libedit2 \
     libgcc-9-dev \
-    libpython2.7 \
+    libpython3.6 \
     libsqlite3-0 \
     libstdc++-9-dev \
     libxml2 \


### PR DESCRIPTION
fixes this error

```
# lldb
lldb: error while loading shared libraries: libpython3.6m.so.1.0: cannot open shared object file: No such file or directory
```

which is https://bugs.swift.org/browse/SR-14099