### PR TITLE
Use `apt-get` instead of `apt`

### DIFF
--- a/swift-ci/master/ubuntu/20.04/Dockerfile
+++ b/swift-ci/master/ubuntu/20.04/Dockerfile
@@ -5,7 +5,7 @@ RUN groupadd -g 998 build-user && \
 
 ENV DEBIAN_FRONTEND="noninteractive"
 
-RUN apt -y update && apt -y install \
+RUN apt-get -y update && apt-get -y install \
   build-essential       \
   clang                 \
   cmake                 \


### PR DESCRIPTION
We currently get a warning in the logs, when we use `apt`:

```
WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
```

From the apt man page:

> ### SCRIPT USAGE AND DIFFERENCES FROM OTHER APT TOOLS
> All features of apt(8) are available in dedicated APT tools like apt-get(8) and apt-cache(8) as well.  apt(8) just changes the default value of some options (see apt.conf(5) and specifically the Binary scope). So you should prefer using these commands (potentially with some additional options enabled) in your scripts as they keep backward compatibility as much as possible.

This pr exchanges uses of `apt` with `apt-get`