### PR TITLE
Add a new Dockerfile for building Swift-DocC-Render-Artifact

### DIFF
--- a/swift-ci/README.md
+++ b/swift-ci/README.md
@@ -11,6 +11,8 @@ The Dockerfiles used for Continuous Integration are layed out under the top leve
 Under that, we have a directory for each of the target branches, e.g.
 Continuous Integration for Swift's `master` branch uses the `swift-ci/master` Dockerfiles.
 
+There is also a specific directory (`swift-docc-render`) for the Dockerfile used to build Swift-DocC-Render. Swift-DocC-Render builds separately from the rest of the projects in the Swift toolchain and ships a pre-built copy for use in the toolchain in the Swift-DocC-Render-Artifact repository.
+
 ## Continuous Integration
 
 This system is designed to support many distributions.

--- a/swift-ci/swift-docc-render/Dockerfile
+++ b/swift-ci/swift-docc-render/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:14.17.4
+
+ARG SWIFT_DOCC_RENDER_BRANCH=main
+
+RUN groupadd -g 998 build-user && \
+    useradd -m -r -u 998 -g build-user build-user
+
+USER build-user
+
+WORKDIR /home/build-user
+
+RUN git clone https://github.com/apple/swift-docc-render.git
+RUN cd swift-docc-render && git checkout $SWIFT_DOCC_RENDER_BRANCH
+RUN /home/build-user/swift-docc-render/build-script-helper.py build --verbose
+RUN /home/build-user/swift-docc-render/build-script-helper.py test --verbose

--- a/swift-ci/swift-docc-render/build-swift-docc-render.sh
+++ b/swift-ci/swift-docc-render/build-swift-docc-render.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2021 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+
+set -e
+
+function usage() {
+  echo "$0 --output-path <output_path> [OPTIONS]"
+  echo ""
+  echo "<output_path> - Path to the directory where the built Swift-DocC-Render will be copied"
+  echo ""
+  echo "OPTIONS"
+  echo ""
+  echo "-h --help"
+  echo "Show help information."
+  echo ""
+  echo "-b --branch"
+  echo "The branch of Swift-DocC-Render to build."
+  echo ""
+}
+
+OUTPUT_PATH=
+BRANCH=main
+
+while [ $# -ne 0 ]; do
+  case "$1" in
+  -o|--output-path)
+    shift
+    OUTPUT_PATH="$1"
+  ;;
+  -b|--branch)
+    shift
+    BRANCH="$1"
+  ;;
+  -h|--help)
+    usage
+    exit 0
+  ;;
+  *)
+    echo "Unrecognised argument \"$1\""
+    echo ""
+    usage
+    exit 1
+  ;;
+  esac
+shift
+done
+
+if [ -z "${OUTPUT_PATH}" ]; then
+echo "Output path cannot be empty. See $0 --help"
+exit 1
+fi
+
+function filepath() {
+  [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
+}
+
+DIRECTORY_ROOT="$(dirname $(filepath $0))"
+DOCKERFILE_PATH="$DIRECTORY_ROOT"/Dockerfile
+
+docker build -t swift-docc-render:latest \
+  --no-cache \
+  --build-arg SWIFT_DOCC_RENDER_BRANCH="$BRANCH" \
+  -f "$DOCKERFILE_PATH" \
+  "$DIRECTORY_ROOT" 
+
+CONTAINER_ID=$(docker create swift-docc-render:latest)
+
+docker cp -a $CONTAINER_ID:/home/build-user/swift-docc-render/dist/. "$OUTPUT_PATH"
+ 
+docker rm $CONTAINER_ID


### PR DESCRIPTION
Bug/issue #, if applicable: rdar://81634420

## Summary

Adds a new Dockerfile that can be used to generate a built version of Swift-DocC-Render in isolation. This allows developers interested in having an up-to-date version of Swift-DocC-Render to build one in an automated way without installing Node.

Developers can build a copy of Swift-DocC-Render at the given branch with the included helper script by running something like the following:

    ./build-swift-docc-render.sh \
        --branch <branch-in-swift-docc-render-repo> \
        --output-path <path-to-output-directory>

The helper script starts by building a new version of the included Docker container with caching disabled. It then copies out the built artifact to the given output directory, and deletes the created Docker container.

> Note: This PR has been opened after closing #251.