### PR TITLE
fix docker images for static linking

### DIFF
--- a/5.5/amazonlinux/2/Dockerfile
+++ b/5.5/amazonlinux/2/Dockerfile
@@ -9,13 +9,13 @@ RUN yum -y install \
   glibc-static \
   gzip \
   libbsd \
-  libcurl \
+  libcurl-devel \
   libedit \
   libicu \
   libsqlite \
   libstdc++-static \
   libuuid \
-  libxml2 \
+  libxml2-devel \
   tar \
   tzdata \
   zlib-devel

--- a/5.5/centos/7/Dockerfile
+++ b/5.5/centos/7/Dockerfile
@@ -8,10 +8,12 @@ RUN yum install shadow-utils.x86_64 -y \
   git \
   glibc-static \
   libbsd-devel \
+  libcurl-devel \
   libedit \
   libedit-devel \
   libicu-devel \
   libstdc++-static \
+  libxml2-devel \
   pkg-config \
   python3 \
   sqlite \

--- a/5.5/centos/8/Dockerfile
+++ b/5.5/centos/8/Dockerfile
@@ -10,10 +10,12 @@ RUN yum install --enablerepo=powertools -y \
   git \
   glibc-static \
   libbsd-devel \
+  libcurl-devel \
   libedit \
   libedit-devel \
   libicu-devel \
   libstdc++-static \
+  libxml2-devel \
   pkg-config \
   python3 \
   sqlite \

--- a/5.5/ubuntu/16.04/Dockerfile
+++ b/5.5/ubuntu/16.04/Dockerfile
@@ -5,8 +5,8 @@ LABEL Description="Docker Container for the Swift programming language"
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
     apt-get -q install -y \
     libatomic1 \
-    libcurl3 \
-    libxml2 \
+    libcurl3-openssl-dev \
+    libxml2-dev \
     libedit2 \
     libsqlite3-0 \
     libc6-dev \

--- a/5.5/ubuntu/18.04/Dockerfile
+++ b/5.5/ubuntu/18.04/Dockerfile
@@ -5,8 +5,8 @@ LABEL Description="Docker Container for the Swift programming language"
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
     apt-get -q install -y \
     libatomic1 \
-    libcurl4 \
-    libxml2 \
+    libcurl4-openssl-dev \
+    libxml2-dev \
     libedit2 \
     libsqlite3-0 \
     libc6-dev \

--- a/5.5/ubuntu/20.04/Dockerfile
+++ b/5.5/ubuntu/20.04/Dockerfile
@@ -8,13 +8,13 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     git \
     gnupg2 \
     libc6-dev \
-    libcurl4 \
+    libcurl4-openssl-dev \
     libedit2 \
     libgcc-9-dev \
     libpython3.8 \
     libsqlite3-0 \
     libstdc++-9-dev \
-    libxml2 \
+    libxml2-dev \
     libz3-dev \
     pkg-config \
     tzdata \

--- a/nightly-5.6/amazonlinux/2/Dockerfile
+++ b/nightly-5.6/amazonlinux/2/Dockerfile
@@ -9,13 +9,13 @@ RUN yum -y install \
   glibc-static \
   gzip \
   libbsd \
-  libcurl \
+  libcurl-devel \
   libedit \
   libicu \
   libsqlite \
   libstdc++-static \
   libuuid \
-  libxml2 \
+  libxml2-devel \
   tar \
   tzdata \
   zlib-devel

--- a/nightly-5.6/amazonlinux/2/buildx/Dockerfile
+++ b/nightly-5.6/amazonlinux/2/buildx/Dockerfile
@@ -9,13 +9,13 @@ RUN yum -y install \
   glibc-static \
   gzip \
   libbsd \
-  libcurl \
+  libcurl-devel \
   libedit \
   libicu \
   libsqlite \
   libstdc++-static \
   libuuid \
-  libxml2 \
+  libxml2-devel \
   tar \
   tzdata \
   zlib-devel
@@ -32,7 +32,7 @@ ARG OS_MAJOR_VER=2
 ARG SWIFT_WEBROOT=https://download.swift.org/swift-5.6-branch
 
 # This is a small trick to enable if/else for arm64 and amd64.
-# Because of https://bugs.swift.org/browse/SR-14872 we need adjust tar options. 
+# Because of https://bugs.swift.org/browse/SR-14872 we need adjust tar options.
 FROM base AS base-amd64
 ARG OS_ARCH_SUFFIX=
 ARG ADDITIONAL_TAR_OPTIONS="--strip-components=1"

--- a/nightly-5.6/centos/7/Dockerfile
+++ b/nightly-5.6/centos/7/Dockerfile
@@ -8,10 +8,12 @@ RUN yum install shadow-utils.x86_64 -y \
   git \
   glibc-static \
   libbsd-devel \
+  libcurl-devel \
   libedit \
   libedit-devel \
   libicu-devel \
   libstdc++-static \
+  libxml2-devel \
   pkg-config \
   python2 \
   python3 \

--- a/nightly-5.6/centos/8/Dockerfile
+++ b/nightly-5.6/centos/8/Dockerfile
@@ -10,10 +10,12 @@ RUN yum install --enablerepo=powertools -y \
   git \
   glibc-static \
   libbsd-devel \
+  libcurl-devel \
   libedit \
   libedit-devel \
   libicu-devel \
   libstdc++-static \
+  libxml2-devel \
   pkg-config \
   python2 \
   sqlite \

--- a/nightly-5.6/centos/8/buildx/Dockerfile
+++ b/nightly-5.6/centos/8/buildx/Dockerfile
@@ -10,10 +10,12 @@ RUN yum install --enablerepo=powertools -y \
   git \
   glibc-static \
   libbsd-devel \
+  libcurl-devel \
   libedit \
   libedit-devel \
   libicu-devel \
   libstdc++-static \
+  libxml2-devel \
   pkg-config \
   python2 \
   sqlite \
@@ -33,7 +35,7 @@ ARG OS_MAJOR_VER=8
 ARG SWIFT_WEBROOT=https://download.swift.org/swift-5.6-branch
 
 # This is a small trick to enable if/else for arm64 and amd64.
-# Because of https://bugs.swift.org/browse/SR-14872 we need adjust tar options. 
+# Because of https://bugs.swift.org/browse/SR-14872 we need adjust tar options.
 FROM base AS base-amd64
 ARG OS_ARCH_SUFFIX=
 ARG ADDITIONAL_TAR_OPTIONS="--strip-components=1"

--- a/nightly-5.6/ubuntu/16.04/Dockerfile
+++ b/nightly-5.6/ubuntu/16.04/Dockerfile
@@ -7,13 +7,13 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     binutils \
     git \
     libc6-dev \
-    libcurl3 \
+    libcurl3-openssl-dev \
     libedit2 \
     libgcc-5-dev \
     libpython3.5 \
     libsqlite3-0 \
     libstdc++-5-dev \
-    libxml2 \
+    libxml2-dev \
     pkg-config \
     tzdata \
     zlib1g-dev \

--- a/nightly-5.6/ubuntu/18.04/Dockerfile
+++ b/nightly-5.6/ubuntu/18.04/Dockerfile
@@ -7,13 +7,13 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     binutils \
     git \
     libc6-dev \
-    libcurl4 \
+    libcurl4-openssl-dev \
     libedit2 \
     libgcc-5-dev \
     libpython3.6 \
     libsqlite3-0 \
     libstdc++-5-dev \
-    libxml2 \
+    libxml2-dev \
     pkg-config \
     tzdata \
     zlib1g-dev \

--- a/nightly-5.6/ubuntu/20.04/Dockerfile
+++ b/nightly-5.6/ubuntu/20.04/Dockerfile
@@ -8,13 +8,13 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     git \
     gnupg2 \
     libc6-dev \
-    libcurl4 \
+    libcurl4-openssl-dev \
     libedit2 \
     libgcc-9-dev \
     libpython3.8 \
     libsqlite3-0 \
     libstdc++-9-dev \
-    libxml2 \
+    libxml2-dev \
     libz3-dev \
     pkg-config \
     tzdata \

--- a/nightly-main/amazonlinux/2/Dockerfile
+++ b/nightly-main/amazonlinux/2/Dockerfile
@@ -9,13 +9,13 @@ RUN yum -y install \
   glibc-static \
   gzip \
   libbsd \
-  libcurl \
+  libcurl-devel \
   libedit \
   libicu \
   libsqlite \
   libstdc++-static \
   libuuid \
-  libxml2 \
+  libxml2-devel \
   tar \
   tzdata \
   zlib-devel

--- a/nightly-main/amazonlinux/2/buildx/Dockerfile
+++ b/nightly-main/amazonlinux/2/buildx/Dockerfile
@@ -9,13 +9,13 @@ RUN yum -y install \
   glibc-static \
   gzip \
   libbsd \
-  libcurl \
+  libcurl-devel \
   libedit \
   libicu \
   libsqlite \
   libstdc++-static \
   libuuid \
-  libxml2 \
+  libxml2-devel \
   tar \
   tzdata \
   zlib-devel
@@ -32,7 +32,7 @@ ARG OS_MAJOR_VER=2
 ARG SWIFT_WEBROOT=https://download.swift.org/development
 
 # This is a small trick to enable if/else for arm64 and amd64.
-# Because of https://bugs.swift.org/browse/SR-14872 we need adjust tar options. 
+# Because of https://bugs.swift.org/browse/SR-14872 we need adjust tar options.
 FROM base AS base-amd64
 ARG OS_ARCH_SUFFIX=
 ARG ADDITIONAL_TAR_OPTIONS="--strip-components=1"

--- a/nightly-main/centos/7/Dockerfile
+++ b/nightly-main/centos/7/Dockerfile
@@ -8,10 +8,12 @@ RUN yum install shadow-utils.x86_64 -y \
   git \
   glibc-static \
   libbsd-devel \
+  libcurl-devel \
   libedit \
   libedit-devel \
   libicu-devel \
   libstdc++-static \
+  libxml2-devel \
   pkg-config \
   python2 \
   python3 \

--- a/nightly-main/centos/8/Dockerfile
+++ b/nightly-main/centos/8/Dockerfile
@@ -10,10 +10,12 @@ RUN yum install --enablerepo=powertools -y \
   git \
   glibc-static \
   libbsd-devel \
+  libcurl-devel \
   libedit \
   libedit-devel \
   libicu-devel \
   libstdc++-static \
+  libxml2-devel \
   pkg-config \
   python2 \
   sqlite \

--- a/nightly-main/centos/8/buildx/Dockerfile
+++ b/nightly-main/centos/8/buildx/Dockerfile
@@ -10,10 +10,12 @@ RUN yum install --enablerepo=powertools -y \
   git \
   glibc-static \
   libbsd-devel \
+  libcurl-devel \
   libedit \
   libedit-devel \
   libicu-devel \
   libstdc++-static \
+  libxml2-devel \
   pkg-config \
   python2 \
   sqlite \
@@ -33,7 +35,7 @@ ARG OS_MAJOR_VER=8
 ARG SWIFT_WEBROOT=https://download.swift.org/development
 
 # This is a small trick to enable if/else for arm64 and amd64.
-# Because of https://bugs.swift.org/browse/SR-14872 we need adjust tar options. 
+# Because of https://bugs.swift.org/browse/SR-14872 we need adjust tar options.
 FROM base AS base-amd64
 ARG OS_ARCH_SUFFIX=
 ARG ADDITIONAL_TAR_OPTIONS="--strip-components=1"

--- a/nightly-main/ubuntu/16.04/Dockerfile
+++ b/nightly-main/ubuntu/16.04/Dockerfile
@@ -7,13 +7,13 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     binutils \
     git \
     libc6-dev \
-    libcurl3 \
+    libcurl3-openssl-dev \
     libedit2 \
     libgcc-5-dev \
     libpython3.5 \
     libsqlite3-0 \
     libstdc++-5-dev \
-    libxml2 \
+    libxml2-dev \
     pkg-config \
     tzdata \
     zlib1g-dev \

--- a/nightly-main/ubuntu/18.04/Dockerfile
+++ b/nightly-main/ubuntu/18.04/Dockerfile
@@ -7,13 +7,13 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     binutils \
     git \
     libc6-dev \
-    libcurl4 \
+    libcurl4-openssl-dev \
     libedit2 \
     libgcc-5-dev \
     libpython3.6 \
     libsqlite3-0 \
     libstdc++-5-dev \
-    libxml2 \
+    libxml2-dev \
     pkg-config \
     tzdata \
     zlib1g-dev \

--- a/nightly-main/ubuntu/20.04/Dockerfile
+++ b/nightly-main/ubuntu/20.04/Dockerfile
@@ -8,13 +8,13 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     git \
     gnupg2 \
     libc6-dev \
-    libcurl4 \
+    libcurl4-openssl-dev \
     libedit2 \
     libgcc-9-dev \
     libpython3.8 \
     libsqlite3-0 \
     libstdc++-9-dev \
-    libxml2 \
+    libxml2-dev \
     libz3-dev \
     pkg-config \
     tzdata \

--- a/nightly-main/ubuntu/20.04/buildx/Dockerfile
+++ b/nightly-main/ubuntu/20.04/buildx/Dockerfile
@@ -8,13 +8,13 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     git \
     gnupg2 \
     libc6-dev \
-    libcurl4 \
+    libcurl4-openssl-dev \
     libedit2 \
     libgcc-9-dev \
     libpython3.8 \
     libsqlite3-0 \
     libstdc++-9-dev \
-    libxml2 \
+    libxml2-dev \
     libz3-dev \
     pkg-config \
     tzdata \
@@ -34,7 +34,7 @@ ARG OS_MIN_VER=04
 ARG SWIFT_WEBROOT=https://download.swift.org/development
 
 # This is a small trick to enable if/else for arm64 and amd64.
-# Because of https://bugs.swift.org/browse/SR-14872 we need adjust tar options. 
+# Because of https://bugs.swift.org/browse/SR-14872 we need adjust tar options.
 FROM base AS base-amd64
 ARG OS_ARCH_SUFFIX=
 ARG ADDITIONAL_TAR_OPTIONS="--strip-components=1"


### PR DESCRIPTION
motivation: statically linkning FoundationNetworking and FoundationXML requires the development version of libcurl and libxml2 respectively

changes:
* update 5.5, 5.6 and nightly docker images to pull the relevant development packages of libcurl and libxml