### PR TITLE
add support for oracle linux 8

### DIFF
--- a/swift-ci/master/oraclelinux/8/Dockerfile
+++ b/swift-ci/master/oraclelinux/8/Dockerfile
@@ -1,0 +1,45 @@
+FROM oraclelinux:8
+
+RUN groupadd -g 42 build-user && \
+    useradd -m -r -u 42 -g build-user build-user
+
+RUN yum install -y oracle-epel-release-el8
+
+RUN yum install --enablerepo=ol8_codeready_builder -y \
+    autoconf              \
+    clang-12.0.1          \
+    cmake                 \
+    diffutils             \
+    git                   \
+    glibc-static          \
+    libbsd-devel          \
+    libcurl-devel         \
+    libedit-devel         \
+    libicu-devel          \
+    libstdc++-static      \
+    libtool               \
+    libuuid-devel         \
+    libxml2-devel         \
+    make                  \
+    ncurses-devel         \
+    ninja-build           \
+    pcre-devel            \
+    procps-ng             \
+    python2               \
+    python2-devel         \
+    python2-six           \
+    python3               \
+    python3-six           \
+    python3-pexpect       \
+    platform-python-devel \
+    sqlite-devel          \
+    swig                  \
+    rsync                 \
+    tar                   \
+    which
+
+RUN ln -s /usr/bin/python2 /usr/bin/python
+
+USER build-user
+
+WORKDIR /home/build-user


### PR DESCRIPTION
motivation: with centos 8 deprecated, teams are moving to oracle linux 8

changes:
* add ci docker setup for producing oracle linux 8 tarballs