### PR TITLE
Add `unzip` to 5.6 toolchain images

### DIFF
--- a/5.6/amazonlinux/2/Dockerfile
+++ b/5.6/amazonlinux/2/Dockerfile
@@ -6,6 +6,7 @@ RUN yum -y install \
   binutils \
   gcc \
   git \
+  unzip \
   glibc-static \
   gzip \
   libbsd \

--- a/5.6/centos/7/Dockerfile
+++ b/5.6/centos/7/Dockerfile
@@ -6,6 +6,7 @@ RUN yum install shadow-utils.x86_64 -y \
   binutils \
   gcc \
   git \
+  unzip \
   glibc-static \
   libbsd-devel \
   libcurl-devel \

--- a/5.6/ubuntu/18.04/Dockerfile
+++ b/5.6/ubuntu/18.04/Dockerfile
@@ -17,6 +17,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     libpython3.6 \
     tzdata \
     git \
+    unzip \
     pkg-config \
     && rm -r /var/lib/apt/lists/*
 

--- a/5.6/ubuntu/20.04/Dockerfile
+++ b/5.6/ubuntu/20.04/Dockerfile
@@ -6,6 +6,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     apt-get -q install -y \
     binutils \
     git \
+    unzip \
     gnupg2 \
     libc6-dev \
     libcurl4-openssl-dev \

--- a/nightly-5.6/centos/8/Dockerfile
+++ b/nightly-5.6/centos/8/Dockerfile
@@ -8,6 +8,7 @@ RUN yum install --enablerepo=powertools -y \
   binutils \
   gcc \
   git \
+  unzip \
   glibc-static \
   libbsd-devel \
   libcurl-devel \

--- a/nightly-5.6/centos/8/buildx/Dockerfile
+++ b/nightly-5.6/centos/8/buildx/Dockerfile
@@ -8,6 +8,7 @@ RUN yum install --enablerepo=powertools -y \
   binutils \
   gcc \
   git \
+  unzip \
   glibc-static \
   libbsd-devel \
   libcurl-devel \

--- a/nightly-main/amazonlinux/2/Dockerfile
+++ b/nightly-main/amazonlinux/2/Dockerfile
@@ -6,6 +6,7 @@ RUN yum -y install \
   binutils \
   gcc \
   git \
+  unzip \
   glibc-static \
   gzip \
   libbsd \

--- a/nightly-main/amazonlinux/2/buildx/Dockerfile
+++ b/nightly-main/amazonlinux/2/buildx/Dockerfile
@@ -6,6 +6,7 @@ RUN yum -y install \
   binutils \
   gcc \
   git \
+  unzip \
   glibc-static \
   gzip \
   libbsd \

--- a/nightly-main/ubuntu/18.04/Dockerfile
+++ b/nightly-main/ubuntu/18.04/Dockerfile
@@ -6,6 +6,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     apt-get -q install -y \
     binutils \
     git \
+    unzip \
     libc6-dev \
     libcurl4-openssl-dev \
     libedit2 \

--- a/nightly-main/ubuntu/20.04/Dockerfile
+++ b/nightly-main/ubuntu/20.04/Dockerfile
@@ -6,6 +6,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     apt-get -q install -y \
     binutils \
     git \
+    unzip \
     gnupg2 \
     libc6-dev \
     libcurl4-openssl-dev \

--- a/nightly-main/ubuntu/20.04/buildx/Dockerfile
+++ b/nightly-main/ubuntu/20.04/buildx/Dockerfile
@@ -6,6 +6,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     apt-get -q install -y \
     binutils \
     git \
+    unzip \
     gnupg2 \
     libc6-dev \
     libcurl4-openssl-dev \


### PR DESCRIPTION
Adds `unzip` to toolchain images to make them available for use in SwiftPM binary targets.

### Motivation

Swift 5.6 adds the option to use binary target dependencies on Linux for Swift package manager plugins. SwiftPM requires the unzip command to be installed to unzip downloads from the internet.

### Changes

- Install `unzip` in Swift toolchain images

cc @tomerd, @abertelrud, @FranzBusch