### PR TITLE
Fix git usability for CentOS 7 nightly images

### DIFF
--- a/nightly-main/centos/7/Dockerfile
+++ b/nightly-main/centos/7/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:7
 LABEL maintainer="Swift Infrastructure <swift-infrastructure@forums.swift.org>"
 LABEL description="Docker Container for the Swift programming language"
 
-# centos 7 ships with git 1.x which is too old for the toolchain usage, using RH software collections to install git 2.x
+# CentOS 7 ships with git 1.x which is too old for the toolchain usage, using RH software collections to install git 2.x
 RUN yum install -y centos-release-scl-rh
 
 RUN yum install shadow-utils.x86_64 -y \
@@ -23,8 +23,10 @@ RUN yum install shadow-utils.x86_64 -y \
   sqlite \
   zlib-devel
 
-# centos 7 ships with git 1.x which is too old for the toolchain usage
-RUN ln -s /opt/rh/rh-git227/root/bin/git /usr/bin/git
+# Enable git 2.x from RH software collections for both login and non-login shells
+RUN ln -s /opt/rh/rh-git227/enable /etc/profile.d/git.sh
+ENV ENV=/etc/profile.d/git.sh
+ENV BASH_ENV=$ENV
 
 RUN sed -i -e 's/\*__block/\*__libc_block/g' /usr/include/unistd.h
 


### PR DESCRIPTION
Git 2.x introduced in #274 is not enabled correctly, because its networking feature depends on `httpd24` from RH software collections, which is not in the library search path.

This PR attempts to enable the Git installation correctly by using the official `enable` script. This also enhances compatibility and robustness against any possible dependency changes.