### PR TITLE
Revert "Use Swift 5.7 base image for Swift CI jobs to support bootstrapping"

### DIFF
--- a/swift-ci/master/amazon-linux/2/Dockerfile
+++ b/swift-ci/master/amazon-linux/2/Dockerfile
@@ -1,8 +1,8 @@
-FROM swift:5.7-amazonlinux2
+FROM amazonlinux:2
 
 RUN yum install shadow-utils -y
 
-RUN groupadd -g 1000 build-user && \
+RUN groupadd -g 998 build-user && \
     useradd -m -r -u 42 -g build-user build-user
 
 # The build needs a package from the EPEL repo so that needs to be enabled.

--- a/swift-ci/master/centos/7/Dockerfile
+++ b/swift-ci/master/centos/7/Dockerfile
@@ -1,8 +1,8 @@
-FROM swift:5.7-centos7
+FROM centos:7
 
 RUN yum install shadow-utils.x86_64 -y
 
-RUN groupadd -g 1000 build-user && \
+RUN groupadd -g 998 build-user && \
     useradd -m -r -u 42 -g build-user build-user
 
 RUN yum install -y epel-release centos-release-scl

--- a/swift-ci/master/ubuntu/18.04/Dockerfile
+++ b/swift-ci/master/ubuntu/18.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM swift:5.7-bionic
+FROM ubuntu:18.04
 
 RUN groupadd -g 998 build-user && \
     useradd -m -r -u 998 -g build-user build-user

--- a/swift-ci/master/ubuntu/20.04/Dockerfile
+++ b/swift-ci/master/ubuntu/20.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM swift:5.7-focal
+FROM ubuntu:20.04
 
 RUN groupadd -g 998 build-user && \
     useradd -m -r -u 998 -g build-user build-user

--- a/swift-ci/master/ubuntu/22.04/Dockerfile
+++ b/swift-ci/master/ubuntu/22.04/Dockerfile
@@ -1,4 +1,4 @@
-FROM swift:5.7-jammy
+FROM ubuntu:22.04
 
 RUN groupadd -g 998 build-user && \
     useradd -m -r -u 998 -g build-user build-user


### PR DESCRIPTION
Reverts apple/swift-docker#314