### PR TITLE
Fix broken `lldb` and `swift repl` in Ubuntu Jammy

### DIFF
--- a/5.7/ubuntu/22.04/Dockerfile
+++ b/5.7/ubuntu/22.04/Dockerfile
@@ -18,6 +18,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     libxml2-dev \
     libz3-dev \
     pkg-config \
+    python3-lldb-13 \
     tzdata \
     zlib1g-dev \
     && rm -r /var/lib/apt/lists/*


### PR DESCRIPTION
Without `python3-lldb-13` installed, running `lldb` or `swift repl` will produce this error:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'lldb'
```