### PR TITLE
Update InstallModules.cmd

### DIFF
--- a/swift-ci/master/windows/10.0.19042.1645/InstallModules.cmd
+++ b/swift-ci/master/windows/10.0.19042.1645/InstallModules.cmd
@@ -5,7 +5,7 @@ FOR /F "tokens=* usebackq" %%r IN (`"%vswhere%" -nologo -latest -all -prerelease
 CALL "%VsDevCmd%" -no_logo -host_arch=amd64 -arch=amd64
 mklink "%UniversalCRTSdkDir%\Include\%UCRTVersion%\ucrt\module.modulemap" S:\SourceCache\swift\stdlib\public\Platform\ucrt.modulemap
 mklink "%UniversalCRTSdkDir%\Include\%UCRTVersion%\um\module.modulemap" S:\SourceCache\swift\stdlib\public\Platform\winsdk.modulemap
-mklink "%VCToolsInstallDir%\include\module.modulemap" S:\SourceCache\swift\stdlib\public\Platform\visualc.modulemap
-mklink "%VCToolsInstallDir%\include\visualc.apinotes" S:\SourceCache\swift\stdlib\public\Platform\visualc.apinotes
+mklink "%VCToolsInstallDir%\include\module.modulemap" S:\SourceCache\swift\stdlib\public\Platform\vcruntime.modulemap
+mklink "%VCToolsInstallDir%\include\vcruntime.apinotes" S:\SourceCache\swift\stdlib\public\Platform\vcruntime.apinotes
 endlocal
 @echo on


### PR DESCRIPTION
Update the InstallModules.cmd to match the renamed files on main in the Swift repository.  This is required to ensure that we are able to build the container properly again.