### PR TITLE
Update CentOS 7 to LLVM/Clang 7

### DIFF
--- a/swift-ci/master/centos/7/Dockerfile
+++ b/swift-ci/master/centos/7/Dockerfile
@@ -19,7 +19,7 @@ RUN yum install --enablerepo=centosplus  -y \
     libtool             \
     libuuid-devel       \
     libxml2-devel       \
-    llvm-toolset-7      \
+    llvm-toolset-7.0    \
     make                \
     ncurses-devel       \
     ninja-build         \
@@ -39,7 +39,7 @@ RUN yum install --enablerepo=centosplus  -y \
     which               \
     zlib-devel
 
-RUN echo -e ". /opt/rh/sclo-git25/enable\n. /opt/rh/llvm-toolset-7/enable\n. /opt/rh/devtoolset-8/enable\n" >> /home/build-user/.bashrc
+RUN echo -e ". /opt/rh/sclo-git25/enable\n. /opt/rh/llvm-toolset-7.0/enable\n. /opt/rh/devtoolset-8/enable\n" >> /home/build-user/.bashrc
 
 RUN sed -i -e 's/\*__block/\*__libc_block/g' /usr/include/unistd.h
 


### PR DESCRIPTION
Note that in `llvm-toolset-7` the 7 refers to the OS version and it had LLVM 3 and 5. But For some reason for LLVM 7 it is now `llvm-toolset-7.0`.