### PR TITLE
bug: fixing 22.04 repl

### DIFF
--- a/5.7/ubuntu/22.04/Dockerfile
+++ b/5.7/ubuntu/22.04/Dockerfile
@@ -12,7 +12,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     libcurl4-openssl-dev \
     libedit2 \
     libgcc-9-dev \
-    libpython3.8 \
+    libpython3-dev \
     libsqlite3-0 \
     libstdc++-9-dev \
     libxml2-dev \

--- a/nightly-5.7/ubuntu/22.04/Dockerfile
+++ b/nightly-5.7/ubuntu/22.04/Dockerfile
@@ -12,7 +12,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     libcurl4-openssl-dev \
     libedit2 \
     libgcc-9-dev \
-    libpython3.8 \
+    libpython3-dev \
     libsqlite3-0 \
     libstdc++-9-dev \
     libxml2-dev \

--- a/nightly-5.7/ubuntu/22.04/buildx/Dockerfile
+++ b/nightly-5.7/ubuntu/22.04/buildx/Dockerfile
@@ -12,7 +12,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     libcurl4-openssl-dev \
     libedit2 \
     libgcc-9-dev \
-    libpython3.8 \
+    libpython3-dev \
     libsqlite3-0 \
     libstdc++-9-dev \
     libxml2-dev \

--- a/nightly-5.8/ubuntu/22.04/Dockerfile
+++ b/nightly-5.8/ubuntu/22.04/Dockerfile
@@ -11,7 +11,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     libcurl4-openssl-dev \
     libedit2 \
     libgcc-9-dev \
-    libpython3.8 \
+    libpython3-dev \
     libsqlite3-0 \
     libstdc++-9-dev \
     libxml2-dev \

--- a/nightly-5.8/ubuntu/22.04/buildx/Dockerfile
+++ b/nightly-5.8/ubuntu/22.04/buildx/Dockerfile
@@ -11,7 +11,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     libcurl4-openssl-dev \
     libedit2 \
     libgcc-9-dev \
-    libpython3.8 \
+    libpython3-dev \
     libsqlite3-0 \
     libstdc++-9-dev \
     libxml2-dev \

--- a/nightly-main/ubuntu/22.04/Dockerfile
+++ b/nightly-main/ubuntu/22.04/Dockerfile
@@ -11,7 +11,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     libcurl4-openssl-dev \
     libedit2 \
     libgcc-9-dev \
-    libpython3.8 \
+    libpython3-dev \
     libsqlite3-0 \
     libstdc++-9-dev \
     libxml2-dev \

--- a/nightly-main/ubuntu/22.04/buildx/Dockerfile
+++ b/nightly-main/ubuntu/22.04/buildx/Dockerfile
@@ -11,7 +11,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     libcurl4-openssl-dev \
     libedit2 \
     libgcc-9-dev \
-    libpython3.8 \
+    libpython3-dev \
     libsqlite3-0 \
     libstdc++-9-dev \
     libxml2-dev \


### PR DESCRIPTION
- iterated through all Dockerfiles for Ubuntu/jammy/22.04, replacing
  libpython3.8 with libpython3-dev to get corrected version of python
  library installed to support `swift repl` command
- fixes #331
