### PR TITLE
Update Jammy dockerfile libstdc++ version

### DIFF
--- a/5.7/ubuntu/22.04/Dockerfile
+++ b/5.7/ubuntu/22.04/Dockerfile
@@ -11,10 +11,10 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     libc6-dev \
     libcurl4-openssl-dev \
     libedit2 \
-    libgcc-9-dev \
+    libgcc-11-dev \
     libpython3-dev \
     libsqlite3-0 \
-    libstdc++-9-dev \
+    libstdc++-11-dev \
     libxml2-dev \
     libz3-dev \
     pkg-config \

--- a/5.8/ubuntu/22.04/Dockerfile
+++ b/5.8/ubuntu/22.04/Dockerfile
@@ -11,10 +11,10 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     libc6-dev \
     libcurl4-openssl-dev \
     libedit2 \
-    libgcc-9-dev \
+    libgcc-11-dev \
     libpython3-dev \
     libsqlite3-0 \
-    libstdc++-9-dev \
+    libstdc++-11-dev \
     libxml2-dev \
     libz3-dev \
     pkg-config \

--- a/nightly-5.7/ubuntu/22.04/Dockerfile
+++ b/nightly-5.7/ubuntu/22.04/Dockerfile
@@ -11,10 +11,10 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     libc6-dev \
     libcurl4-openssl-dev \
     libedit2 \
-    libgcc-9-dev \
+    libgcc-11-dev \
     libpython3-dev \
     libsqlite3-0 \
-    libstdc++-9-dev \
+    libstdc++-11-dev \
     libxml2-dev \
     libz3-dev \
     pkg-config \

--- a/nightly-5.7/ubuntu/22.04/buildx/Dockerfile
+++ b/nightly-5.7/ubuntu/22.04/buildx/Dockerfile
@@ -11,10 +11,10 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     libc6-dev \
     libcurl4-openssl-dev \
     libedit2 \
-    libgcc-9-dev \
+    libgcc-11-dev \
     libpython3-dev \
     libsqlite3-0 \
-    libstdc++-9-dev \
+    libstdc++-11-dev \
     libxml2-dev \
     libz3-dev \
     pkg-config \

--- a/nightly-5.8/ubuntu/22.04/Dockerfile
+++ b/nightly-5.8/ubuntu/22.04/Dockerfile
@@ -10,10 +10,10 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     libc6-dev \
     libcurl4-openssl-dev \
     libedit2 \
-    libgcc-9-dev \
+    libgcc-11-dev \
     libpython3-dev \
     libsqlite3-0 \
-    libstdc++-9-dev \
+    libstdc++-11-dev \
     libxml2-dev \
     libz3-dev \
     pkg-config \

--- a/nightly-5.8/ubuntu/22.04/buildx/Dockerfile
+++ b/nightly-5.8/ubuntu/22.04/buildx/Dockerfile
@@ -10,10 +10,10 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     libc6-dev \
     libcurl4-openssl-dev \
     libedit2 \
-    libgcc-9-dev \
+    libgcc-11-dev \
     libpython3-dev \
     libsqlite3-0 \
-    libstdc++-9-dev \
+    libstdc++-11-dev \
     libxml2-dev \
     libz3-dev \
     pkg-config \

--- a/nightly-5.9/ubuntu/22.04/Dockerfile
+++ b/nightly-5.9/ubuntu/22.04/Dockerfile
@@ -10,10 +10,10 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     libc6-dev \
     libcurl4-openssl-dev \
     libedit2 \
-    libgcc-9-dev \
+    libgcc-11-dev \
     libpython3-dev \
     libsqlite3-0 \
-    libstdc++-9-dev \
+    libstdc++-11-dev \
     libxml2-dev \
     libz3-dev \
     pkg-config \

--- a/nightly-5.9/ubuntu/22.04/buildx/Dockerfile
+++ b/nightly-5.9/ubuntu/22.04/buildx/Dockerfile
@@ -10,10 +10,10 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     libc6-dev \
     libcurl4-openssl-dev \
     libedit2 \
-    libgcc-9-dev \
+    libgcc-11-dev \
     libpython3-dev \
     libsqlite3-0 \
-    libstdc++-9-dev \
+    libstdc++-11-dev \
     libxml2-dev \
     libz3-dev \
     pkg-config \

--- a/nightly-main/ubuntu/22.04/Dockerfile
+++ b/nightly-main/ubuntu/22.04/Dockerfile
@@ -10,10 +10,10 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     libc6-dev \
     libcurl4-openssl-dev \
     libedit2 \
-    libgcc-9-dev \
+    libgcc-11-dev \
     libpython3-dev \
     libsqlite3-0 \
-    libstdc++-9-dev \
+    libstdc++-11-dev \
     libxml2-dev \
     libz3-dev \
     pkg-config \

--- a/nightly-main/ubuntu/22.04/buildx/Dockerfile
+++ b/nightly-main/ubuntu/22.04/buildx/Dockerfile
@@ -10,10 +10,10 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     libc6-dev \
     libcurl4-openssl-dev \
     libedit2 \
-    libgcc-9-dev \
+    libgcc-11-dev \
     libpython3-dev \
     libsqlite3-0 \
-    libstdc++-9-dev \
+    libstdc++-11-dev \
     libxml2-dev \
     libz3-dev \
     pkg-config \


### PR DESCRIPTION
Jammy uses the gcc-11 aligned c/c++ libraries and runtimes, but we force-install the gcc-9 aligned versions. If you install any tools from the Ubuntu-official repositories (e.g libtool), you'll get error messages because clang will look for the C++ headers aligned with the newest gcc version (11), instead of what we installed (9), so folks need to know to manually install `libstdc++-11-dev` if they want to do that, which is bad.

```
$ echo "#include <cerrno>" | clang++ -std=c++11 -xc++ -c -o /dev/null -
$ apt update && apt install libtool
$ echo "#include <cerrno>" | clang++ -std=c++11 -xc++ -c -o /dev/null -
<stdin>:1:10: fatal error: 'cerrno' file not found
#include <cerrno>
         ^~~~~~~~
1 error generated.
$ apt install libstdc++-11-dev
$ echo "#include <cerrno>" | clang++ -std=c++11 -xc++ -c -o /dev/null -
$
```

apt info for `gcc`, which depends on `gcc-11`.

```
$ apt show gcc
Package: gcc
Version: 4:11.2.0-1ubuntu1
Priority: optional
Build-Essential: yes
Section: devel
Source: gcc-defaults (1.193ubuntu1)
Origin: Ubuntu
Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
Original-Maintainer: Debian GCC Maintainers <debian-gcc@lists.debian.org>
Bugs: https://bugs.launchpad.net/ubuntu/+filebug
Installed-Size: 51.2 kB
Provides: c-compiler, gcc-aarch64-linux-gnu (= 4:11.2.0-1ubuntu1)
Depends: cpp (= 4:11.2.0-1ubuntu1), gcc-11 (>= 11.2.0-1~)
Recommends: libc6-dev | libc-dev
Suggests: gcc-multilib, make, manpages-dev, autoconf, automake, libtool, flex, bison, gdb, gcc-doc
Conflicts: gcc-doc (<< 1:2.95.3)
Task: ubuntustudio-video, ubuntustudio-publishing, ubuntu-mate-core, ubuntu-mate-desktop
Download-Size: 5128 B
APT-Manual-Installed: no
APT-Sources: http://ports.ubuntu.com/ubuntu-ports jammy/main arm64 Packages
Description: GNU C compiler
```

rdar://109112170