### PR TITLE
Install a Swift 5.8.1 toolchain in all swift-ci images

### DIFF
--- a/swift-ci/master/amazon-linux/2/Dockerfile
+++ b/swift-ci/master/amazon-linux/2/Dockerfile
@@ -46,7 +46,6 @@ RUN mkdir -p /usr/local/lib/python3.7/site-packages/
 
 RUN easy_install-3.7 six
 
-ARG SWIFT_SIGNING_KEY=A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
 ARG SWIFT_PLATFORM=amazonlinux2
 ARG SWIFT_VERSION=5.8.1
 ARG SWIFT_BRANCH=swift-${SWIFT_VERSION}-release
@@ -54,8 +53,7 @@ ARG SWIFT_TAG=swift-${SWIFT_VERSION}-RELEASE
 ARG SWIFT_WEBROOT=https://download.swift.org
 ARG SWIFT_PREFIX=/opt/swift/${SWIFT_VERSION}
 
-ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
-    SWIFT_PLATFORM=$SWIFT_PLATFORM \
+ENV SWIFT_PLATFORM=$SWIFT_PLATFORM \
     SWIFT_VERSION=$SWIFT_VERSION \
     SWIFT_BRANCH=$SWIFT_BRANCH \
     SWIFT_TAG=$SWIFT_TAG \
@@ -81,7 +79,7 @@ RUN set -e; \
     # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
     && export GNUPGHOME="$(mktemp -d)" \
     && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \
-    && gpg --batch --quiet --keyserver keyserver.ubuntu.com --recv-keys "$SWIFT_SIGNING_KEY" \
+    && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
     && gpg --batch --verify swift.tar.gz.sig swift.tar.gz \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && mkdir -p $SWIFT_PREFIX \

--- a/swift-ci/master/amazon-linux/2/Dockerfile
+++ b/swift-ci/master/amazon-linux/2/Dockerfile
@@ -12,7 +12,6 @@ RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.n
 # Update and install needed build packages
 RUN yum -y group install "development tools"
 RUN yum -y install \
-  clang            \
   cmake            \
   curl-devel       \
   gcc-c++          \
@@ -46,6 +45,51 @@ RUN yum -y install \
 RUN mkdir -p /usr/local/lib/python3.7/site-packages/
 
 RUN easy_install-3.7 six
+
+ARG SWIFT_SIGNING_KEY=A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
+ARG SWIFT_PLATFORM=amazonlinux2
+ARG SWIFT_VERSION=5.8.1
+ARG SWIFT_BRANCH=swift-${SWIFT_VERSION}-release
+ARG SWIFT_TAG=swift-${SWIFT_VERSION}-RELEASE
+ARG SWIFT_WEBROOT=https://download.swift.org
+ARG SWIFT_PREFIX=/opt/swift/${SWIFT_VERSION}
+
+ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
+    SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    SWIFT_VERSION=$SWIFT_VERSION \
+    SWIFT_BRANCH=$SWIFT_BRANCH \
+    SWIFT_TAG=$SWIFT_TAG \
+    SWIFT_WEBROOT=$SWIFT_WEBROOT \
+    SWIFT_PREFIX=$SWIFT_PREFIX
+
+RUN set -e; \
+    ARCH_NAME="$(rpm --eval '%{_arch}')"; \
+    url=; \
+    case "${ARCH_NAME##*-}" in \
+        'x86_64') \
+            OS_ARCH_SUFFIX=''; \
+            ;; \
+        'aarch64') \
+            OS_ARCH_SUFFIX='-aarch64'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture: '$ARCH_NAME'"; exit 1 ;; \
+    esac; \
+    SWIFT_WEBDIR="$SWIFT_WEBROOT/$SWIFT_BRANCH/$(echo $SWIFT_PLATFORM | tr -d .)$OS_ARCH_SUFFIX" \
+    && SWIFT_BIN_URL="$SWIFT_WEBDIR/$SWIFT_TAG/$SWIFT_TAG-$SWIFT_PLATFORM$OS_ARCH_SUFFIX.tar.gz" \
+    && SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
+    && echo $SWIFT_BIN_URL \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \
+    && gpg --batch --quiet --keyserver keyserver.ubuntu.com --recv-keys "$SWIFT_SIGNING_KEY" \
+    && gpg --batch --verify swift.tar.gz.sig swift.tar.gz \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && mkdir -p $SWIFT_PREFIX \
+    && tar -xzf swift.tar.gz --directory $SWIFT_PREFIX --strip-components=1 \
+    && chmod -R o+r $SWIFT_PREFIX/usr/lib/swift \
+    && rm -rf "$GNUPGHOME" swift.tar.gz.sig swift.tar.gz
+
+ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
 
 USER build-user
 

--- a/swift-ci/master/centos/7/Dockerfile
+++ b/swift-ci/master/centos/7/Dockerfile
@@ -44,7 +44,6 @@ RUN echo -e ". /opt/rh/sclo-git25/enable\n. /opt/rh/devtoolset-8/enable\n" >> /h
 
 RUN sed -i -e 's/\*__block/\*__libc_block/g' /usr/include/unistd.h
 
-ARG SWIFT_SIGNING_KEY=A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
 ARG SWIFT_PLATFORM=centos7
 ARG SWIFT_VERSION=5.8.1
 ARG SWIFT_BRANCH=swift-${SWIFT_VERSION}-release
@@ -52,8 +51,7 @@ ARG SWIFT_TAG=swift-${SWIFT_VERSION}-RELEASE
 ARG SWIFT_WEBROOT=https://download.swift.org
 ARG SWIFT_PREFIX=/opt/swift/${SWIFT_VERSION}
 
-ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
-    SWIFT_PLATFORM=$SWIFT_PLATFORM \
+ENV SWIFT_PLATFORM=$SWIFT_PLATFORM \
     SWIFT_VERSION=$SWIFT_VERSION \
     SWIFT_BRANCH=$SWIFT_BRANCH \
     SWIFT_TAG=$SWIFT_TAG \
@@ -67,7 +65,7 @@ RUN set -e; \
     # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
     && export GNUPGHOME="$(mktemp -d)" \
     && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \
-    && gpg --batch --quiet --keyserver keyserver.ubuntu.com --recv-keys "$SWIFT_SIGNING_KEY" \
+    && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
     && gpg --batch --verify swift.tar.gz.sig swift.tar.gz \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && mkdir -p $SWIFT_PREFIX \

--- a/swift-ci/master/centos/7/Dockerfile
+++ b/swift-ci/master/centos/7/Dockerfile
@@ -19,7 +19,6 @@ RUN yum install --enablerepo=centosplus  -y \
     libtool             \
     libuuid-devel       \
     libxml2-devel       \
-    llvm-toolset-7.0    \
     make                \
     ncurses-devel       \
     ninja-build         \
@@ -41,12 +40,42 @@ RUN yum install --enablerepo=centosplus  -y \
     zip                 \
     zlib-devel
 
-RUN echo -e ". /opt/rh/sclo-git25/enable\n. /opt/rh/llvm-toolset-7.0/enable\n. /opt/rh/devtoolset-8/enable\n" >> /home/build-user/.bashrc
-
-RUN echo /opt/rh/llvm-toolset-7.0/root/usr/lib64/ > /etc/ld.so.conf.d/llvm-toolset.conf
-RUN ldconfig
+RUN echo -e ". /opt/rh/sclo-git25/enable\n. /opt/rh/devtoolset-8/enable\n" >> /home/build-user/.bashrc
 
 RUN sed -i -e 's/\*__block/\*__libc_block/g' /usr/include/unistd.h
+
+ARG SWIFT_SIGNING_KEY=A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
+ARG SWIFT_PLATFORM=centos7
+ARG SWIFT_VERSION=5.8.1
+ARG SWIFT_BRANCH=swift-${SWIFT_VERSION}-release
+ARG SWIFT_TAG=swift-${SWIFT_VERSION}-RELEASE
+ARG SWIFT_WEBROOT=https://download.swift.org
+ARG SWIFT_PREFIX=/opt/swift/${SWIFT_VERSION}
+
+ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
+    SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    SWIFT_VERSION=$SWIFT_VERSION \
+    SWIFT_BRANCH=$SWIFT_BRANCH \
+    SWIFT_TAG=$SWIFT_TAG \
+    SWIFT_WEBROOT=$SWIFT_WEBROOT \
+    SWIFT_PREFIX=$SWIFT_PREFIX
+
+RUN set -e; \
+    SWIFT_WEBDIR="$SWIFT_WEBROOT/$SWIFT_BRANCH/$(echo $SWIFT_PLATFORM | tr -d .)" \
+    && SWIFT_BIN_URL="$SWIFT_WEBDIR/$SWIFT_TAG/$SWIFT_TAG-$SWIFT_PLATFORM.tar.gz" \
+    && SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \
+    && gpg --batch --quiet --keyserver keyserver.ubuntu.com --recv-keys "$SWIFT_SIGNING_KEY" \
+    && gpg --batch --verify swift.tar.gz.sig swift.tar.gz \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && mkdir -p $SWIFT_PREFIX \
+    && tar -xzf swift.tar.gz --directory $SWIFT_PREFIX --strip-components=1 \
+    && chmod -R o+r $SWIFT_PREFIX/usr/lib/swift \
+    && rm -rf "$GNUPGHOME" swift.tar.gz.sig swift.tar.gz
+
+ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
 
 USER build-user
 

--- a/swift-ci/master/rhel-ubi/9/Dockerfile
+++ b/swift-ci/master/rhel-ubi/9/Dockerfile
@@ -19,7 +19,6 @@ RUN yum install -y  \
   unzip             \
   zip
 
-ARG SWIFT_SIGNING_KEY=A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
 ARG SWIFT_PLATFORM=ubi9
 ARG SWIFT_VERSION=5.8.1
 ARG SWIFT_BRANCH=swift-${SWIFT_VERSION}-release
@@ -27,8 +26,7 @@ ARG SWIFT_TAG=swift-${SWIFT_VERSION}-RELEASE
 ARG SWIFT_WEBROOT=https://download.swift.org
 ARG SWIFT_PREFIX=/opt/swift/${SWIFT_VERSION}
 
-ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
-    SWIFT_PLATFORM=$SWIFT_PLATFORM \
+ENV SWIFT_PLATFORM=$SWIFT_PLATFORM \
     SWIFT_VERSION=$SWIFT_VERSION \
     SWIFT_BRANCH=$SWIFT_BRANCH \
     SWIFT_TAG=$SWIFT_TAG \
@@ -54,7 +52,7 @@ RUN set -e; \
     # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
     && export GNUPGHOME="$(mktemp -d)" \
     && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \
-    && gpg --batch --quiet --keyserver keyserver.ubuntu.com --recv-keys "$SWIFT_SIGNING_KEY" \
+    && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
     && gpg --batch --verify swift.tar.gz.sig swift.tar.gz \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && mkdir -p $SWIFT_PREFIX \

--- a/swift-ci/master/rhel-ubi/9/Dockerfile
+++ b/swift-ci/master/rhel-ubi/9/Dockerfile
@@ -6,7 +6,6 @@ RUN groupadd -g 42 build-user && \
 RUN yum install -y  \
   git               \
   gcc-c++           \
-  clang             \
   cmake             \
   make              \
   libcurl-devel     \
@@ -19,6 +18,51 @@ RUN yum install -y  \
   sqlite-devel      \
   unzip             \
   zip
+
+ARG SWIFT_SIGNING_KEY=A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
+ARG SWIFT_PLATFORM=ubi9
+ARG SWIFT_VERSION=5.8.1
+ARG SWIFT_BRANCH=swift-${SWIFT_VERSION}-release
+ARG SWIFT_TAG=swift-${SWIFT_VERSION}-RELEASE
+ARG SWIFT_WEBROOT=https://download.swift.org
+ARG SWIFT_PREFIX=/opt/swift/${SWIFT_VERSION}
+
+ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
+    SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    SWIFT_VERSION=$SWIFT_VERSION \
+    SWIFT_BRANCH=$SWIFT_BRANCH \
+    SWIFT_TAG=$SWIFT_TAG \
+    SWIFT_WEBROOT=$SWIFT_WEBROOT \
+    SWIFT_PREFIX=$SWIFT_PREFIX
+
+RUN set -e; \
+    ARCH_NAME="$(rpm --eval '%{_arch}')"; \
+    url=; \
+    case "${ARCH_NAME##*-}" in \
+        'x86_64') \
+            OS_ARCH_SUFFIX=''; \
+            ;; \
+        'aarch64') \
+            OS_ARCH_SUFFIX='-aarch64'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture: '$ARCH_NAME'"; exit 1 ;; \
+    esac; \
+    SWIFT_WEBDIR="$SWIFT_WEBROOT/$SWIFT_BRANCH/$(echo $SWIFT_PLATFORM | tr -d .)$OS_ARCH_SUFFIX" \
+    && SWIFT_BIN_URL="$SWIFT_WEBDIR/$SWIFT_TAG/$SWIFT_TAG-$SWIFT_PLATFORM$OS_ARCH_SUFFIX.tar.gz" \
+    && SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
+    && echo $SWIFT_BIN_URL \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \
+    && gpg --batch --quiet --keyserver keyserver.ubuntu.com --recv-keys "$SWIFT_SIGNING_KEY" \
+    && gpg --batch --verify swift.tar.gz.sig swift.tar.gz \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && mkdir -p $SWIFT_PREFIX \
+    && tar -xzf swift.tar.gz --directory $SWIFT_PREFIX --strip-components=1 \
+    && chmod -R o+r $SWIFT_PREFIX/usr/lib/swift \
+    && rm -rf "$GNUPGHOME" swift.tar.gz.sig swift.tar.gz
+
+ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
 
 USER build-user
 

--- a/swift-ci/master/rhel-ubi/9/Dockerfile
+++ b/swift-ci/master/rhel-ubi/9/Dockerfile
@@ -7,6 +7,7 @@ RUN yum install -y  \
   git               \
   gcc-c++           \
   cmake             \
+  diffutils         \
   make              \
   libcurl-devel     \
   libedit-devel     \

--- a/swift-ci/master/ubuntu/18.04/Dockerfile
+++ b/swift-ci/master/ubuntu/18.04/Dockerfile
@@ -7,7 +7,6 @@ ENV DEBIAN_FRONTEND="noninteractive"
 
 RUN apt -y update && apt -y install \
   build-essential       \
-  clang                 \
   cmake                 \
   git                   \
   icu-devtools          \
@@ -33,6 +32,43 @@ RUN apt -y update && apt -y install \
   tzdata                \
   uuid-dev              \
   zip
+
+ARG SWIFT_SIGNING_KEY=A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
+ARG SWIFT_PLATFORM=ubuntu18.04
+ARG SWIFT_VERSION=5.8.1
+ARG SWIFT_BRANCH=swift-${SWIFT_VERSION}-release
+ARG SWIFT_TAG=swift-${SWIFT_VERSION}-RELEASE
+ARG SWIFT_WEBROOT=https://download.swift.org
+ARG SWIFT_PREFIX=/opt/swift/${SWIFT_VERSION}
+
+ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
+    SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    SWIFT_VERSION=$SWIFT_VERSION \
+    SWIFT_BRANCH=$SWIFT_BRANCH \
+    SWIFT_TAG=$SWIFT_TAG \
+    SWIFT_WEBROOT=$SWIFT_WEBROOT \
+    SWIFT_PREFIX=$SWIFT_PREFIX
+
+RUN set -e; \
+    SWIFT_WEBDIR="$SWIFT_WEBROOT/$SWIFT_BRANCH/$(echo $SWIFT_PLATFORM | tr -d .)" \
+    && SWIFT_BIN_URL="$SWIFT_WEBDIR/$SWIFT_TAG/$SWIFT_TAG-$SWIFT_PLATFORM.tar.gz" \
+    && SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
+    # - Grab curl here so we cache better up above
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \
+    && gpg --batch --quiet --keyserver keyserver.ubuntu.com --recv-keys "$SWIFT_SIGNING_KEY" \
+    && gpg --batch --verify swift.tar.gz.sig swift.tar.gz \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && mkdir -p $SWIFT_PREFIX \
+    && tar -xzf swift.tar.gz --directory $SWIFT_PREFIX --strip-components=1 \
+    && chmod -R o+r $SWIFT_PREFIX/usr/lib/swift \
+    && rm -rf "$GNUPGHOME" swift.tar.gz.sig swift.tar.gz \
+    && apt-get purge --auto-remove -y curl
+
+ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
 
 USER build-user
 

--- a/swift-ci/master/ubuntu/18.04/Dockerfile
+++ b/swift-ci/master/ubuntu/18.04/Dockerfile
@@ -33,7 +33,6 @@ RUN apt -y update && apt -y install \
   uuid-dev              \
   zip
 
-ARG SWIFT_SIGNING_KEY=A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
 ARG SWIFT_PLATFORM=ubuntu18.04
 ARG SWIFT_VERSION=5.8.1
 ARG SWIFT_BRANCH=swift-${SWIFT_VERSION}-release
@@ -41,8 +40,7 @@ ARG SWIFT_TAG=swift-${SWIFT_VERSION}-RELEASE
 ARG SWIFT_WEBROOT=https://download.swift.org
 ARG SWIFT_PREFIX=/opt/swift/${SWIFT_VERSION}
 
-ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
-    SWIFT_PLATFORM=$SWIFT_PLATFORM \
+ENV SWIFT_PLATFORM=$SWIFT_PLATFORM \
     SWIFT_VERSION=$SWIFT_VERSION \
     SWIFT_BRANCH=$SWIFT_BRANCH \
     SWIFT_TAG=$SWIFT_TAG \
@@ -59,7 +57,7 @@ RUN set -e; \
     # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
     && export GNUPGHOME="$(mktemp -d)" \
     && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \
-    && gpg --batch --quiet --keyserver keyserver.ubuntu.com --recv-keys "$SWIFT_SIGNING_KEY" \
+    && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
     && gpg --batch --verify swift.tar.gz.sig swift.tar.gz \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && mkdir -p $SWIFT_PREFIX \

--- a/swift-ci/master/ubuntu/20.04/Dockerfile
+++ b/swift-ci/master/ubuntu/20.04/Dockerfile
@@ -32,7 +32,6 @@ RUN apt-get -y update && apt-get -y install \
   uuid-dev              \
   zip
 
-ARG SWIFT_SIGNING_KEY=A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
 ARG SWIFT_PLATFORM=ubuntu20.04
 ARG SWIFT_VERSION=5.8.1
 ARG SWIFT_BRANCH=swift-${SWIFT_VERSION}-release
@@ -40,8 +39,7 @@ ARG SWIFT_TAG=swift-${SWIFT_VERSION}-RELEASE
 ARG SWIFT_WEBROOT=https://download.swift.org
 ARG SWIFT_PREFIX=/opt/swift/${SWIFT_VERSION}
 
-ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
-    SWIFT_PLATFORM=$SWIFT_PLATFORM \
+ENV SWIFT_PLATFORM=$SWIFT_PLATFORM \
     SWIFT_VERSION=$SWIFT_VERSION \
     SWIFT_BRANCH=$SWIFT_BRANCH \
     SWIFT_TAG=$SWIFT_TAG \
@@ -69,7 +67,7 @@ RUN set -e; \
     # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
     && export GNUPGHOME="$(mktemp -d)" \
     && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \
-    && gpg --batch --quiet --keyserver keyserver.ubuntu.com --recv-keys "$SWIFT_SIGNING_KEY" \
+    && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
     && gpg --batch --verify swift.tar.gz.sig swift.tar.gz \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && mkdir -p $SWIFT_PREFIX \

--- a/swift-ci/master/ubuntu/20.04/Dockerfile
+++ b/swift-ci/master/ubuntu/20.04/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get -y update && apt-get -y install \
   python2-dev           \
   python3-six           \
   python3-distutils     \
+  python3-pkg-resources \
   python3-psutil        \
   rsync                 \
   swig                  \

--- a/swift-ci/master/ubuntu/20.04/Dockerfile
+++ b/swift-ci/master/ubuntu/20.04/Dockerfile
@@ -7,7 +7,6 @@ ENV DEBIAN_FRONTEND="noninteractive"
 
 RUN apt-get -y update && apt-get -y install \
   build-essential       \
-  clang                 \
   cmake                 \
   git                   \
   icu-devtools          \
@@ -32,6 +31,54 @@ RUN apt-get -y update && apt-get -y install \
   tzdata                \
   uuid-dev              \
   zip
+
+ARG SWIFT_SIGNING_KEY=A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
+ARG SWIFT_PLATFORM=ubuntu20.04
+ARG SWIFT_VERSION=5.8.1
+ARG SWIFT_BRANCH=swift-${SWIFT_VERSION}-release
+ARG SWIFT_TAG=swift-${SWIFT_VERSION}-RELEASE
+ARG SWIFT_WEBROOT=https://download.swift.org
+ARG SWIFT_PREFIX=/opt/swift/${SWIFT_VERSION}
+
+ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
+    SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    SWIFT_VERSION=$SWIFT_VERSION \
+    SWIFT_BRANCH=$SWIFT_BRANCH \
+    SWIFT_TAG=$SWIFT_TAG \
+    SWIFT_WEBROOT=$SWIFT_WEBROOT \
+    SWIFT_PREFIX=$SWIFT_PREFIX
+
+RUN set -e; \
+    ARCH_NAME="$(dpkg --print-architecture)"; \
+    url=; \
+    case "${ARCH_NAME##*-}" in \
+        'amd64') \
+            OS_ARCH_SUFFIX=''; \
+            ;; \
+        'arm64') \
+            OS_ARCH_SUFFIX='-aarch64'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture: '$ARCH_NAME'"; exit 1 ;; \
+    esac; \
+    SWIFT_WEBDIR="$SWIFT_WEBROOT/$SWIFT_BRANCH/$(echo $SWIFT_PLATFORM | tr -d .)$OS_ARCH_SUFFIX" \
+    && SWIFT_BIN_URL="$SWIFT_WEBDIR/$SWIFT_TAG/$SWIFT_TAG-$SWIFT_PLATFORM$OS_ARCH_SUFFIX.tar.gz" \
+    && SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
+    # - Grab curl here so we cache better up above
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \
+    && gpg --batch --quiet --keyserver keyserver.ubuntu.com --recv-keys "$SWIFT_SIGNING_KEY" \
+    && gpg --batch --verify swift.tar.gz.sig swift.tar.gz \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && mkdir -p $SWIFT_PREFIX \
+    && tar -xzf swift.tar.gz --directory $SWIFT_PREFIX --strip-components=1 \
+    && chmod -R o+r $SWIFT_PREFIX/usr/lib/swift \
+    && rm -rf "$GNUPGHOME" swift.tar.gz.sig swift.tar.gz \
+    && apt-get purge --auto-remove -y curl
+
+ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
 
 USER build-user
 

--- a/swift-ci/master/ubuntu/22.04/Dockerfile
+++ b/swift-ci/master/ubuntu/22.04/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get -y update && apt-get -y install \
   python2-dev           \
   python3-six           \
   python3-distutils     \
+  python3-pkg-resources \
   python3-psutil        \
   rsync                 \
   swig                  \

--- a/swift-ci/master/ubuntu/22.04/Dockerfile
+++ b/swift-ci/master/ubuntu/22.04/Dockerfile
@@ -7,7 +7,6 @@ ENV DEBIAN_FRONTEND="noninteractive"
 
 RUN apt-get -y update && apt-get -y install \
   build-essential       \
-  clang                 \
   cmake                 \
   git                   \
   icu-devtools          \
@@ -32,6 +31,54 @@ RUN apt-get -y update && apt-get -y install \
   tzdata                \
   uuid-dev              \
   zip
+
+ARG SWIFT_SIGNING_KEY=A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
+ARG SWIFT_PLATFORM=ubuntu22.04
+ARG SWIFT_VERSION=5.8.1
+ARG SWIFT_BRANCH=swift-${SWIFT_VERSION}-release
+ARG SWIFT_TAG=swift-${SWIFT_VERSION}-RELEASE
+ARG SWIFT_WEBROOT=https://download.swift.org
+ARG SWIFT_PREFIX=/opt/swift/${SWIFT_VERSION}
+
+ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
+    SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    SWIFT_VERSION=$SWIFT_VERSION \
+    SWIFT_BRANCH=$SWIFT_BRANCH \
+    SWIFT_TAG=$SWIFT_TAG \
+    SWIFT_WEBROOT=$SWIFT_WEBROOT \
+    SWIFT_PREFIX=$SWIFT_PREFIX
+
+RUN set -e; \
+    ARCH_NAME="$(dpkg --print-architecture)"; \
+    url=; \
+    case "${ARCH_NAME##*-}" in \
+        'amd64') \
+            OS_ARCH_SUFFIX=''; \
+            ;; \
+        'arm64') \
+            OS_ARCH_SUFFIX='-aarch64'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture: '$ARCH_NAME'"; exit 1 ;; \
+    esac; \
+    SWIFT_WEBDIR="$SWIFT_WEBROOT/$SWIFT_BRANCH/$(echo $SWIFT_PLATFORM | tr -d .)$OS_ARCH_SUFFIX" \
+    && SWIFT_BIN_URL="$SWIFT_WEBDIR/$SWIFT_TAG/$SWIFT_TAG-$SWIFT_PLATFORM$OS_ARCH_SUFFIX.tar.gz" \
+    && SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
+    # - Grab curl here so we cache better up above
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \
+    && gpg --batch --quiet --keyserver keyserver.ubuntu.com --recv-keys "$SWIFT_SIGNING_KEY" \
+    && gpg --batch --verify swift.tar.gz.sig swift.tar.gz \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && mkdir -p $SWIFT_PREFIX \
+    && tar -xzf swift.tar.gz --directory $SWIFT_PREFIX --strip-components=1 \
+    && chmod -R o+r $SWIFT_PREFIX/usr/lib/swift \
+    && rm -rf "$GNUPGHOME" swift.tar.gz.sig swift.tar.gz \
+    && apt-get purge --auto-remove -y curl
+
+ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
 
 USER build-user
 

--- a/swift-ci/master/ubuntu/22.04/Dockerfile
+++ b/swift-ci/master/ubuntu/22.04/Dockerfile
@@ -32,7 +32,6 @@ RUN apt-get -y update && apt-get -y install \
   uuid-dev              \
   zip
 
-ARG SWIFT_SIGNING_KEY=A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
 ARG SWIFT_PLATFORM=ubuntu22.04
 ARG SWIFT_VERSION=5.8.1
 ARG SWIFT_BRANCH=swift-${SWIFT_VERSION}-release
@@ -40,8 +39,7 @@ ARG SWIFT_TAG=swift-${SWIFT_VERSION}-RELEASE
 ARG SWIFT_WEBROOT=https://download.swift.org
 ARG SWIFT_PREFIX=/opt/swift/${SWIFT_VERSION}
 
-ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
-    SWIFT_PLATFORM=$SWIFT_PLATFORM \
+ENV SWIFT_PLATFORM=$SWIFT_PLATFORM \
     SWIFT_VERSION=$SWIFT_VERSION \
     SWIFT_BRANCH=$SWIFT_BRANCH \
     SWIFT_TAG=$SWIFT_TAG \
@@ -69,7 +67,7 @@ RUN set -e; \
     # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
     && export GNUPGHOME="$(mktemp -d)" \
     && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \
-    && gpg --batch --quiet --keyserver keyserver.ubuntu.com --recv-keys "$SWIFT_SIGNING_KEY" \
+    && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
     && gpg --batch --verify swift.tar.gz.sig swift.tar.gz \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && mkdir -p $SWIFT_PREFIX \


### PR DESCRIPTION
Installs a Swift 5.8.1 toolchain into `/opt/swift/<version>` on each Linux platform. Removes clang since the toolchain clang can be used instead.