### PR TITLE
Update slim images to include swift-backtrace.

### DIFF
--- a/nightly-5.9/amazonlinux/2/slim/Dockerfile
+++ b/nightly-5.9/amazonlinux/2/slim/Dockerfile
@@ -35,8 +35,10 @@ RUN set -e; \
     && gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && yum -y install tar gzip \
-    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 ${DOWNLOAD_DIR}-${OS_VER}/usr/lib/swift/linux \
-    && chmod -R o+r /usr/lib/swift \
+    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
+       ${DOWNLOAD_DIR}-${OS_VER}/usr/lib/swift/linux \
+       ${DOWNLOAD_DIR}-${OS_VER}/usr/libexec/swift/linux \
+    && chmod -R o+r /usr/lib/swift /usr/libexec/swift \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
     && yum autoremove -y tar gzip
 

--- a/nightly-5.9/centos/7/slim/Dockerfile
+++ b/nightly-5.9/centos/7/slim/Dockerfile
@@ -34,7 +34,9 @@ RUN set -e; \
     && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
     && gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
     # - Unpack the toolchain, set libs permissions, and clean up.
-    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 ${DOWNLOAD_DIR}-${OS_VER}/usr/lib/swift/linux \
+    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
+       ${DOWNLOAD_DIR}-${OS_VER}/usr/lib/swift/linux \
+       ${DOWNLOAD_DIR}-${OS_VER}/usr/libexec/swift/linux \
     && chmod -R o+r /usr/lib/swift \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 

--- a/nightly-5.9/rhel-ubi/9/slim/Dockerfile
+++ b/nightly-5.9/rhel-ubi/9/slim/Dockerfile
@@ -34,8 +34,10 @@ RUN set -e; \
     && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
     && gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
     # - Unpack the toolchain, set libs permissions, and clean up.
-    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 ${DOWNLOAD_DIR}-${OS_VER}/usr/lib/swift/linux \
-    && chmod -R o+r /usr/lib/swift \
+    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
+       ${DOWNLOAD_DIR}-${OS_VER}/usr/lib/swift/linux \
+       ${DOWNLOAD_DIR}-${OS_VER}/usr/libexec/swift/linux \
+    && chmod -R o+r /usr/lib/swift /usr/libexec/swift \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \

--- a/nightly-5.9/ubuntu/18.04/slim/Dockerfile
+++ b/nightly-5.9/ubuntu/18.04/slim/Dockerfile
@@ -44,8 +44,10 @@ RUN set -e; \
     && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
     && gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
     # - Unpack the toolchain, set libs permissions, and clean up.
-    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 ${DOWNLOAD_DIR}-${OS_VER}/usr/lib/swift/linux \
-    && chmod -R o+r /usr/lib/swift \
+    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
+       ${DOWNLOAD_DIR}-${OS_VER}/usr/lib/swift/linux \
+       ${DOWNLOAD_DIR}-${OS_VER}/usr/libexec/swift/linux \
+    && chmod -R o+r /usr/lib/swift /usr/libexec/swift \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
     && apt-get purge --auto-remove -y curl gnupg
 

--- a/nightly-5.9/ubuntu/20.04/slim/Dockerfile
+++ b/nightly-5.9/ubuntu/20.04/slim/Dockerfile
@@ -44,8 +44,10 @@ RUN set -e; \
     && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
     && gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
     # - Unpack the toolchain, set libs permissions, and clean up.
-    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 ${DOWNLOAD_DIR}-${OS_VER}/usr/lib/swift/linux \
-    && chmod -R o+r /usr/lib/swift \
+    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
+       ${DOWNLOAD_DIR}-${OS_VER}/usr/lib/swift/linux \
+       ${DOWNLOAD_DIR}-${OS_VER}/usr/libexec/swift/linux \
+    && chmod -R o+r /usr/lib/swift /usr/libexec/swift \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
     && apt-get purge --auto-remove -y curl gnupg
 

--- a/nightly-5.9/ubuntu/22.04/slim/Dockerfile
+++ b/nightly-5.9/ubuntu/22.04/slim/Dockerfile
@@ -44,8 +44,10 @@ RUN set -e; \
     && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
     && gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
     # - Unpack the toolchain, set libs permissions, and clean up.
-    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 ${DOWNLOAD_DIR}-${OS_VER}/usr/lib/swift/linux \
-    && chmod -R o+r /usr/lib/swift \
+    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
+       ${DOWNLOAD_DIR}-${OS_VER}/usr/lib/swift/linux \
+       ${DOWNLOAD_DIR}-${OS_VER}/usr/libexec/swift/linux \
+    && chmod -R o+r /usr/lib/swift /usr/libexec/swift \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
     && apt-get purge --auto-remove -y curl gnupg
 

--- a/nightly-main/amazonlinux/2/slim/Dockerfile
+++ b/nightly-main/amazonlinux/2/slim/Dockerfile
@@ -35,8 +35,10 @@ RUN set -e; \
     && gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && yum -y install tar gzip \
-    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 ${DOWNLOAD_DIR}-${OS_VER}/usr/lib/swift/linux \
-    && chmod -R o+r /usr/lib/swift \
+    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
+       ${DOWNLOAD_DIR}-${OS_VER}/usr/lib/swift/linux \
+       ${DOWNLOAD_DIR}-${OS_VER}/usr/libexec/swift/linux \
+    && chmod -R o+r /usr/lib/swift /usr/libexec/swift \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
     && yum autoremove -y tar gzip
 

--- a/nightly-main/centos/7/slim/Dockerfile
+++ b/nightly-main/centos/7/slim/Dockerfile
@@ -34,8 +34,10 @@ RUN set -e; \
     && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
     && gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
     # - Unpack the toolchain, set libs permissions, and clean up.
-    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 ${DOWNLOAD_DIR}-${OS_VER}/usr/lib/swift/linux \
-    && chmod -R o+r /usr/lib/swift \
+    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
+       ${DOWNLOAD_DIR}-${OS_VER}/usr/lib/swift/linux \
+       ${DOWNLOAD_DIR}-${OS_VER}/usr/libexec/swift/linux \
+    && chmod -R o+r /usr/lib/swift /usr/libexec/swift \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \

--- a/nightly-main/rhel-ubi/9/slim/Dockerfile
+++ b/nightly-main/rhel-ubi/9/slim/Dockerfile
@@ -34,8 +34,10 @@ RUN set -e; \
     && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
     && gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
     # - Unpack the toolchain, set libs permissions, and clean up.
-    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 ${DOWNLOAD_DIR}-${OS_VER}/usr/lib/swift/linux \
-    && chmod -R o+r /usr/lib/swift \
+    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
+       ${DOWNLOAD_DIR}-${OS_VER}/usr/lib/swift/linux \
+       ${DOWNLOAD_DIR}-${OS_VER}/usr/libexec/swift/linux \
+    && chmod -R o+r /usr/lib/swift /usr/libexec/swift \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \

--- a/nightly-main/ubuntu/18.04/slim/Dockerfile
+++ b/nightly-main/ubuntu/18.04/slim/Dockerfile
@@ -44,8 +44,10 @@ RUN set -e; \
     && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
     && gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
     # - Unpack the toolchain, set libs permissions, and clean up.
-    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 ${DOWNLOAD_DIR}-${OS_VER}/usr/lib/swift/linux \
-    && chmod -R o+r /usr/lib/swift \
+    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
+       ${DOWNLOAD_DIR}-${OS_VER}/usr/lib/swift/linux \
+       ${DOWNLOAD_DIR}-${OS_VER}/usr/libexec/swift/linux \
+    && chmod -R o+r /usr/lib/swift /usr/libexec/swift \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
     && apt-get purge --auto-remove -y curl gnupg
 

--- a/nightly-main/ubuntu/20.04/slim/Dockerfile
+++ b/nightly-main/ubuntu/20.04/slim/Dockerfile
@@ -44,8 +44,10 @@ RUN set -e; \
     && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
     && gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
     # - Unpack the toolchain, set libs permissions, and clean up.
-    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 ${DOWNLOAD_DIR}-${OS_VER}/usr/lib/swift/linux \
-    && chmod -R o+r /usr/lib/swift \
+    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
+       ${DOWNLOAD_DIR}-${OS_VER}/usr/lib/swift/linux \
+       ${DOWNLOAD_DIR}-${OS_VER}/usr/libexec/swift/linux \
+    && chmod -R o+r /usr/lib/swift /usr/libexec/swift \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
     && apt-get purge --auto-remove -y curl gnupg
 

--- a/nightly-main/ubuntu/22.04/slim/Dockerfile
+++ b/nightly-main/ubuntu/22.04/slim/Dockerfile
@@ -44,8 +44,10 @@ RUN set -e; \
     && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
     && gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
     # - Unpack the toolchain, set libs permissions, and clean up.
-    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 ${DOWNLOAD_DIR}-${OS_VER}/usr/lib/swift/linux \
-    && chmod -R o+r /usr/lib/swift \
+    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
+       ${DOWNLOAD_DIR}-${OS_VER}/usr/lib/swift/linux \
+       ${DOWNLOAD_DIR}-${OS_VER}/usr/libexec/swift/linux \
+    && chmod -R o+r /usr/lib/swift /usr/libexec/swift \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
     && apt-get purge --auto-remove -y curl gnupg
 


### PR DESCRIPTION
The slim images should include swift-backtrace as well as the runtime libraries.

rdar://112966082