### PR TITLE
Fix Centos slim image slightly.

### DIFF
--- a/nightly-5.9/centos/7/slim/Dockerfile
+++ b/nightly-5.9/centos/7/slim/Dockerfile
@@ -37,7 +37,7 @@ RUN set -e; \
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
        ${DOWNLOAD_DIR}-${OS_VER}/usr/lib/swift/linux \
        ${DOWNLOAD_DIR}-${OS_VER}/usr/libexec/swift/linux \
-    && chmod -R o+r /usr/lib/swift \
+    && chmod -R o+r /usr/lib/swift /usr/libexec/swift \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \


### PR DESCRIPTION
Apparently I missed adding libexec to the `chmod`.

rdar://112966082