### PR TITLE
Swift 5.9-dev: CentOS7: Symlink libstdc++_nonshared.a into static swift

### DIFF
--- a/nightly-5.9/centos/7/Dockerfile
+++ b/nightly-5.9/centos/7/Dockerfile
@@ -60,6 +60,19 @@ RUN set -e; \
     && chmod -R o+r /usr/lib/swift \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
+# The devtoolset-8 that the Swift runtime is built against uses new
+# functionality in the backdeploy `libstdc++_noshared.a` in devtoolset-a.
+# A linkerscript in the devtoolset ensures that it is picked up appropriately.
+# When dynamically linking the runtime, this static archive is merged into the
+# shared object. When static linking, the compat library needs to be available
+# to be merged into the final shared object/executable.
+#
+# Symlink it from the devtoolset into the static swift resource directory
+RUN yum install -y centos-release-scl
+RUN yum install -y devtoolset-8
+RUN ln -s /opt/rh/devtoolset-8/root/usr/lib/gcc/x86_64-redhat-linux/8/libstdc++_nonshared.a /usr/lib/swift_static/linux && \
+    ln -s /opt/rh/devtoolset-8/root/usr/lib/gcc/x86_64-redhat-linux/8/libstdc++.so /usr/lib/swift_static/linux
+
 # Print Installed Swift Version
 RUN swift --version
 

--- a/nightly-main/centos/7/Dockerfile
+++ b/nightly-main/centos/7/Dockerfile
@@ -68,6 +68,19 @@ RUN set -e; \
     && chmod -R o+r /usr/lib/swift \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
+# The devtoolset-8 that the Swift runtime is built against uses new
+# functionality in the backdeploy `libstdc++_noshared.a` in devtoolset-a.
+# A linkerscript in the devtoolset ensures that it is picked up appropriately.
+# When dynamically linking the runtime, this static archive is merged into the
+# shared object. When static linking, the compat library needs to be available
+# to be merged into the final shared object/executable.
+#
+# Symlink it from the devtoolset into the static swift resource directory
+RUN yum install -y centos-release-scl
+RUN yum install -y devtoolset-8
+RUN ln -s /opt/rh/devtoolset-8/root/usr/lib/gcc/x86_64-redhat-linux/8/libstdc++_nonshared.a /usr/lib/swift_static/linux && \
+    ln -s /opt/rh/devtoolset-8/root/usr/lib/gcc/x86_64-redhat-linux/8/libstdc++.so /usr/lib/swift_static/linux
+
 # Print Installed Swift Version
 RUN swift --version
 


### PR DESCRIPTION
The swift compiler and runtime libraries are built against the devtoolset-8 on centOS-7. The devtoolset has additional functionality on top of the base centos-7 libstdc++. When the standard library is built as a dynamic library, the extra functionality is linked into the DSO directly, so the dependency is hidden. When the standard library is built as a static archive, it the extra functionality isn't. This is correct behavior to avoid over-linking in the final executable, but it means that the library needs to be present when building statically and in a place that the compiler will look for resources.

This symlinks the backpack library with the additional functionality, along with the linker script to tell the linker to link it into anything that needs to use libstdc++.so.

rdar://114669418