### PR TITLE
Windows: restore the python installation and change the base image

### DIFF
--- a/5.9/windows/LTSC2022/Dockerfile
+++ b/5.9/windows/LTSC2022/Dockerfile
@@ -1,13 +1,11 @@
-FROM mcr.microsoft.com/windows-cssc/python:3.9-servercore-ltsc2022 AS windows
+FROM mcr.microsoft.com/windows/servercore:ltsc2022 AS windows
 
 LABEL maintainer="Swift Infrastructure <swift-infrastructure@forums.swift.org>"
 LABEL description="Docker Container for the Swift programming language"
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ENV PYTHONHOME C:\Python
 ENV PYTHONIOENCODING UTF-8
-ENV PYTHONPATH C:\Python\lib
 
 # Install Git.
 # See: git-[version]-[bit].exe /SAVEINF=git.inf and /?
@@ -112,6 +110,43 @@ RUN Write-Host -NoNewLine ('Downloading {0} ... ' -f ${env:SWIFT});             
       exit 1;                                                                   \
     }                                                                           \
     Remove-Item -Force installer.exe;                                           \
+    Remove-Item -ErrorAction SilentlyContinue -Force -Recurse ${env:TEMP}\*
+
+# Install Python
+ARG PY39=https://www.python.org/ftp/python/3.9.13/python-3.9.13-amd64.exe
+ARG PY39_SHA256=FB3D0466F3754752CA7FD839A09FFE53375FF2C981279FD4BC23A005458F7F5D
+RUN Write-Host -NoNewLine ('Downloading {0} ... ' -f ${env:PY39});              \
+    Invoke-WebRequest -Uri ${env:PY39} -OutFile python-3.9.13-amd64.exe;        \
+    Write-Host '✓';                                                             \
+    Write-Host -NoNewLine ('Verifying SHA256 ({0}) ... ' -f ${env:PY39_SH256}); \
+    $Hash = Get-FileHash python-3.9.13-amd64.exe -Algorithm sha256;             \
+    if ($Hash.Hash -eq ${env:PY39_SHA256}) {                                    \
+      Write-Host '✓';                                                           \
+    } else {                                                                    \
+      Write-Host ('✘ ({0})' -f $Hash.Hash);                                     \
+      exit 1;                                                                   \
+    }                                                                           \
+    Write-Host -NoNewLine 'Installing Python ... ';                             \
+    $Process =                                                                  \
+        Start-Process python-3.9.13-amd64.exe -Wait -PassThru -NoNewWindow -ArgumentList @( \
+           'AssociateFiles=0',                                                  \
+           'Include_doc=0',                                                     \
+           'Include_debug=0',                                                   \
+           'Include_lib=1',                                                     \
+           'Include_tcltk=0',                                                   \
+           'Include_test=0',                                                    \
+           'InstallAllUsers=1',                                                 \
+           'InstallLauncherAllUsers=0',                                         \
+           'PrependPath=1',                                                     \
+           '/quiet'                                                             \
+         );                                                                     \
+    if ($Process.ExitCode -eq 0) {                                              \
+      Write-Host '✓';                                                           \
+    } else {                                                                    \
+      Write-Host ('✘ ({0})' -f $Process.ExitCode);                              \
+      exit 1;                                                                   \
+    }                                                                           \
+    Remove-Item -Force python-3.9.13-amd64.exe;                                 \
     Remove-Item -ErrorAction SilentlyContinue -Force -Recurse ${env:TEMP}\*
 
 # Default to powershell


### PR DESCRIPTION
Restore the python installation and the base image as the base image is a requirement for the docker-library.