### PR TITLE
Windows: swap install order for python and VSB

### DIFF
--- a/5.9/windows/LTSC2022/Dockerfile
+++ b/5.9/windows/LTSC2022/Dockerfile
@@ -51,6 +51,43 @@ RUN Write-Host -NoNewLine ('Downloading {0} ... ' -f ${env:GIT});               
     Remove-Item -Force git.exe;                                                 \
     Remove-Item -ErrorAction SilentlyContinue -Force -Recurse ${env:TEMP}\*
 
+# Install Python
+ARG PY39=https://www.python.org/ftp/python/3.9.13/python-3.9.13-amd64.exe
+ARG PY39_SHA256=FB3D0466F3754752CA7FD839A09FFE53375FF2C981279FD4BC23A005458F7F5D
+RUN Write-Host -NoNewLine ('Downloading {0} ... ' -f ${env:PY39});              \
+    Invoke-WebRequest -Uri ${env:PY39} -OutFile python-3.9.13-amd64.exe;        \
+    Write-Host '✓';                                                             \
+    Write-Host -NoNewLine ('Verifying SHA256 ({0}) ... ' -f ${env:PY39_SHA256});\
+    $Hash = Get-FileHash python-3.9.13-amd64.exe -Algorithm sha256;             \
+    if ($Hash.Hash -eq ${env:PY39_SHA256}) {                                    \
+      Write-Host '✓';                                                           \
+    } else {                                                                    \
+      Write-Host ('✘ ({0})' -f $Hash.Hash);                                     \
+      exit 1;                                                                   \
+    }                                                                           \
+    Write-Host -NoNewLine 'Installing Python ... ';                             \
+    $Process =                                                                  \
+        Start-Process python-3.9.13-amd64.exe -Wait -PassThru -NoNewWindow -ArgumentList @( \
+           'AssociateFiles=0',                                                  \
+           'Include_doc=0',                                                     \
+           'Include_debug=0',                                                   \
+           'Include_lib=1',                                                     \
+           'Include_tcltk=0',                                                   \
+           'Include_test=0',                                                    \
+           'InstallAllUsers=1',                                                 \
+           'InstallLauncherAllUsers=0',                                         \
+           'PrependPath=1',                                                     \
+           '/quiet'                                                             \
+         );                                                                     \
+    if ($Process.ExitCode -eq 0) {                                              \
+      Write-Host '✓';                                                           \
+    } else {                                                                    \
+      Write-Host ('✘ ({0})' -f $Process.ExitCode);                              \
+      exit 1;                                                                   \
+    }                                                                           \
+    Remove-Item -Force python-3.9.13-amd64.exe;                                 \
+    Remove-Item -ErrorAction SilentlyContinue -Force -Recurse ${env:TEMP}\*
+
 # Install Visual Studio Build Tools
 ARG VSB=https://aka.ms/vs/17/release/vs_buildtools.exe
 ARG VSB_SHA256=D4E08524CB0E5BD061A24F507928D1CFB91DCE192C5E12ED964B8343FC4CDEDD
@@ -110,43 +147,6 @@ RUN Write-Host -NoNewLine ('Downloading {0} ... ' -f ${env:SWIFT});             
       exit 1;                                                                   \
     }                                                                           \
     Remove-Item -Force installer.exe;                                           \
-    Remove-Item -ErrorAction SilentlyContinue -Force -Recurse ${env:TEMP}\*
-
-# Install Python
-ARG PY39=https://www.python.org/ftp/python/3.9.13/python-3.9.13-amd64.exe
-ARG PY39_SHA256=FB3D0466F3754752CA7FD839A09FFE53375FF2C981279FD4BC23A005458F7F5D
-RUN Write-Host -NoNewLine ('Downloading {0} ... ' -f ${env:PY39});              \
-    Invoke-WebRequest -Uri ${env:PY39} -OutFile python-3.9.13-amd64.exe;        \
-    Write-Host '✓';                                                             \
-    Write-Host -NoNewLine ('Verifying SHA256 ({0}) ... ' -f ${env:PY39_SH256}); \
-    $Hash = Get-FileHash python-3.9.13-amd64.exe -Algorithm sha256;             \
-    if ($Hash.Hash -eq ${env:PY39_SHA256}) {                                    \
-      Write-Host '✓';                                                           \
-    } else {                                                                    \
-      Write-Host ('✘ ({0})' -f $Hash.Hash);                                     \
-      exit 1;                                                                   \
-    }                                                                           \
-    Write-Host -NoNewLine 'Installing Python ... ';                             \
-    $Process =                                                                  \
-        Start-Process python-3.9.13-amd64.exe -Wait -PassThru -NoNewWindow -ArgumentList @( \
-           'AssociateFiles=0',                                                  \
-           'Include_doc=0',                                                     \
-           'Include_debug=0',                                                   \
-           'Include_lib=1',                                                     \
-           'Include_tcltk=0',                                                   \
-           'Include_test=0',                                                    \
-           'InstallAllUsers=1',                                                 \
-           'InstallLauncherAllUsers=0',                                         \
-           'PrependPath=1',                                                     \
-           '/quiet'                                                             \
-         );                                                                     \
-    if ($Process.ExitCode -eq 0) {                                              \
-      Write-Host '✓';                                                           \
-    } else {                                                                    \
-      Write-Host ('✘ ({0})' -f $Process.ExitCode);                              \
-      exit 1;                                                                   \
-    }                                                                           \
-    Remove-Item -Force python-3.9.13-amd64.exe;                                 \
     Remove-Item -ErrorAction SilentlyContinue -Force -Recurse ${env:TEMP}\*
 
 # Default to powershell


### PR DESCRIPTION
Supposedly the ordering matters and reduces the size by ~900M.