### PR TITLE
added install openssl-devel to amazonlinux2 Dockerfile

### DIFF
--- a/5.10/amazonlinux/2/Dockerfile
+++ b/5.10/amazonlinux/2/Dockerfile
@@ -17,6 +17,7 @@ RUN yum -y install \
   libstdc++-static \
   libuuid \
   libxml2-devel \
+  openssl-devel \
   tar \
   tzdata \
   zlib-devel

--- a/5.9/amazonlinux/2/Dockerfile
+++ b/5.9/amazonlinux/2/Dockerfile
@@ -17,6 +17,7 @@ RUN yum -y install \
   libstdc++-static \
   libuuid \
   libxml2-devel \
+  openssl-devel \
   tar \
   tzdata \
   zlib-devel

--- a/nightly-5.10/amazonlinux/2/Dockerfile
+++ b/nightly-5.10/amazonlinux/2/Dockerfile
@@ -16,6 +16,7 @@ RUN yum -y install \
   libstdc++-static \
   libuuid \
   libxml2-devel \
+  openssl-devel \
   tar \
   tzdata \
   unzip \

--- a/nightly-5.10/amazonlinux/2/buildx/Dockerfile
+++ b/nightly-5.10/amazonlinux/2/buildx/Dockerfile
@@ -16,6 +16,7 @@ RUN yum -y install \
   libstdc++-static \
   libuuid \
   libxml2-devel \
+  openssl-devel \
   tar \
   tzdata \
   unzip \

--- a/nightly-5.9/amazonlinux/2/Dockerfile
+++ b/nightly-5.9/amazonlinux/2/Dockerfile
@@ -16,6 +16,7 @@ RUN yum -y install \
   libstdc++-static \
   libuuid \
   libxml2-devel \
+  openssl-devel \
   tar \
   tzdata \
   unzip \

--- a/nightly-5.9/amazonlinux/2/buildx/Dockerfile
+++ b/nightly-5.9/amazonlinux/2/buildx/Dockerfile
@@ -16,6 +16,7 @@ RUN yum -y install \
   libstdc++-static \
   libuuid \
   libxml2-devel \
+  openssl-devel \
   tar \
   tzdata \
   unzip \

--- a/nightly-main/amazonlinux/2/Dockerfile
+++ b/nightly-main/amazonlinux/2/Dockerfile
@@ -16,6 +16,7 @@ RUN yum -y install \
   libstdc++-static \
   libuuid \
   libxml2-devel \
+  openssl-devel \
   tar \
   tzdata \
   unzip \

--- a/nightly-main/amazonlinux/2/buildx/Dockerfile
+++ b/nightly-main/amazonlinux/2/buildx/Dockerfile
@@ -16,6 +16,7 @@ RUN yum -y install \
   libstdc++-static \
   libuuid \
   libxml2-devel \
+  openssl-devel \
   tar \
   tzdata \
   unzip \


### PR DESCRIPTION
# Swift build for AWS Lambda failing

When using the command "swift package --disable-sandbox plugin archive" to build a Swift Lambda function that has aws-sdk-swift as a dependency, the build of it will fail because of a missing package in the image it uses. This is why I added openssl-devel in the install section.

## Reproducing the Bug

1. Initialize a Swift project for AWS Lambda
```bash
swift package init --type executable 
```
2. edit overall project to conform to a Lambda function

for example

```swift
// Import the packages required by our function
import AWSLambdaRuntime

// Define the request structure
struct Request: Codable {
    let rawPath: String
}

// Define the response structure
struct Response: Codable {
    let body: String
}

// Entry point for the Lambda function
@main
struct HelloWorld: SimpleLambdaHandler {

    // Lambda Function handler
    func handle(_ event: Request, context: LambdaContext) async throws -> Response {

        return Response(body: "Hello, world!")
    }
}
````

make sure to put this into Sources/HelloWorld/LambdaHandler.swift

4. add aws-sdk-swift as a **package** and as a **product** dependency
```swift
// swift-tools-version: 5.9.0
// The swift-tools-version declares the minimum version of Swift required to build this package.

import PackageDescription

let package = Package(
    name: "aws-swift-app",
    platforms: [.macOS(.v12)],
    products: [
        .executable(name: "HelloWorld", targets: ["HelloWorld"])
    ],
    dependencies: [
        .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime", branch: "main"),
        .package(url: "https://github.com/awslabs/aws-sdk-swift", from: "0.37.0")
    ],
    targets: [
        .executableTarget(
            name: "HelloWorld",
            dependencies: [
                .product(name: "AWSLambdaRuntime",package: "swift-aws-lambda-runtime"),
                .product(name: "AWSDynamoDB",package: "aws-sdk-swift"),
            ]
        )
    ]
)
```
5. run the command
```bash
swift package --disable-sandbox plugin archive
```

## The Error

The project would start compiling until it prints this:

<img width="1090" alt="Capture d’écran 2024-03-01 à 17 37 44" src="https://github.com/apple/swift-docker/assets/100198937/5833a603-4f34-4232-a01f-8233856f2eee">

Which basically says that it is missing some files

## The Fix

Adding openssl-devel to the installed packages in the amazonlinux2 image which is the image that swift package uses.

