### PR TITLE
Correct the padding on the /etc/motd banners

### DIFF
--- a/nightly-5.10/amazonlinux/2/Dockerfile
+++ b/nightly-5.10/amazonlinux/2/Dockerfile
@@ -62,13 +62,14 @@ RUN set -e; \
 # Print Installed Swift Version
 RUN swift --version
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bashrc; \
-    echo -e " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd
 
 RUN echo 'source /etc/bashrc' >> /root/.bashrc

--- a/nightly-5.10/amazonlinux/2/buildx/Dockerfile
+++ b/nightly-5.10/amazonlinux/2/buildx/Dockerfile
@@ -69,13 +69,14 @@ RUN set -e; \
 # Print Installed Swift Version
 RUN swift --version
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bashrc; \
-    echo -e " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd
 
 RUN echo 'source /etc/bashrc' >> /root/.bashrc

--- a/nightly-5.10/amazonlinux/2/slim/Dockerfile
+++ b/nightly-5.10/amazonlinux/2/slim/Dockerfile
@@ -42,13 +42,14 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
     && yum autoremove -y tar gzip
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bashrc; \
-    echo -e " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd
 
 RUN echo 'source /etc/bashrc' >> /root/.bashrc

--- a/nightly-5.10/centos/7/Dockerfile
+++ b/nightly-5.10/centos/7/Dockerfile
@@ -63,11 +63,12 @@ RUN set -e; \
 # Print Installed Swift Version
 RUN swift --version
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bashrc; \
-    echo -e " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-5.10/centos/7/slim/Dockerfile
+++ b/nightly-5.10/centos/7/slim/Dockerfile
@@ -40,11 +40,12 @@ RUN set -e; \
     && chmod -R o+r /usr/lib/swift /usr/libexec/swift \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bashrc; \
-    echo -e " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-5.10/rhel-ubi/9/Dockerfile
+++ b/nightly-5.10/rhel-ubi/9/Dockerfile
@@ -56,11 +56,12 @@ RUN set -e; \
 # Print Installed Swift Version
 RUN swift --version
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bashrc; \
-    echo -e " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-5.10/rhel-ubi/9/buildx/Dockerfile
+++ b/nightly-5.10/rhel-ubi/9/buildx/Dockerfile
@@ -62,13 +62,14 @@ RUN set -e; \
 # Print Installed Swift Version
 RUN swift --version
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bashrc; \
-    echo -e " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd
 
 RUN echo 'source /etc/bashrc' >> /root/.bashrc

--- a/nightly-5.10/rhel-ubi/9/slim/Dockerfile
+++ b/nightly-5.10/rhel-ubi/9/slim/Dockerfile
@@ -40,11 +40,12 @@ RUN set -e; \
     && chmod -R o+r /usr/lib/swift /usr/libexec/swift \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bashrc; \
-    echo -e " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-5.10/ubuntu/18.04/Dockerfile
+++ b/nightly-5.10/ubuntu/18.04/Dockerfile
@@ -63,11 +63,12 @@ RUN set -e; \
 # Print Installed Swift Version
 RUN swift --version
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bash.bashrc; \
-    echo " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bash.bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-5.10/ubuntu/18.04/slim/Dockerfile
+++ b/nightly-5.10/ubuntu/18.04/slim/Dockerfile
@@ -51,11 +51,12 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
     && apt-get purge --auto-remove -y curl gnupg
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bash.bashrc; \
-    echo " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bash.bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-5.10/ubuntu/20.04/Dockerfile
+++ b/nightly-5.10/ubuntu/20.04/Dockerfile
@@ -67,11 +67,12 @@ RUN set -e; \
 # Print Installed Swift Version
 RUN swift --version
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bash.bashrc; \
-    echo " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ ! -z \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bash.bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-5.10/ubuntu/20.04/buildx/Dockerfile
+++ b/nightly-5.10/ubuntu/20.04/buildx/Dockerfile
@@ -73,11 +73,12 @@ RUN set -e; \
 # Print Installed Swift Version
 RUN swift --version
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bash.bashrc; \
-    echo " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bash.bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-5.10/ubuntu/20.04/slim/Dockerfile
+++ b/nightly-5.10/ubuntu/20.04/slim/Dockerfile
@@ -51,11 +51,12 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
     && apt-get purge --auto-remove -y curl gnupg
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bash.bashrc; \
-    echo " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bash.bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-5.10/ubuntu/22.04/Dockerfile
+++ b/nightly-5.10/ubuntu/22.04/Dockerfile
@@ -67,11 +67,12 @@ RUN set -e; \
 # Print Installed Swift Version
 RUN swift --version
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bash.bashrc; \
-    echo " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bash.bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-5.10/ubuntu/22.04/buildx/Dockerfile
+++ b/nightly-5.10/ubuntu/22.04/buildx/Dockerfile
@@ -73,11 +73,12 @@ RUN set -e; \
 # Print Installed Swift Version
 RUN swift --version
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bash.bashrc; \
-    echo " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bash.bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-5.10/ubuntu/22.04/slim/Dockerfile
+++ b/nightly-5.10/ubuntu/22.04/slim/Dockerfile
@@ -51,11 +51,12 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
     && apt-get purge --auto-remove -y curl gnupg
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bash.bashrc; \
-    echo " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bash.bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-6.0/amazonlinux/2/Dockerfile
+++ b/nightly-6.0/amazonlinux/2/Dockerfile
@@ -62,13 +62,14 @@ RUN set -e; \
 # Print Installed Swift Version
 RUN swift --version
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bashrc; \
-    echo -e " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd
 
 RUN echo 'source /etc/bashrc' >> /root/.bashrc

--- a/nightly-6.0/amazonlinux/2/buildx/Dockerfile
+++ b/nightly-6.0/amazonlinux/2/buildx/Dockerfile
@@ -69,13 +69,14 @@ RUN set -e; \
 # Print Installed Swift Version
 RUN swift --version
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bashrc; \
-    echo -e " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd
 
 RUN echo 'source /etc/bashrc' >> /root/.bashrc

--- a/nightly-6.0/amazonlinux/2/slim/Dockerfile
+++ b/nightly-6.0/amazonlinux/2/slim/Dockerfile
@@ -42,13 +42,14 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
     && yum autoremove -y tar gzip
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bashrc; \
-    echo -e " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd
 
 RUN echo 'source /etc/bashrc' >> /root/.bashrc

--- a/nightly-6.0/centos/7/Dockerfile
+++ b/nightly-6.0/centos/7/Dockerfile
@@ -84,11 +84,12 @@ RUN ln -s /opt/rh/devtoolset-8/root/usr/lib/gcc/x86_64-redhat-linux/8/libstdc++_
 # Print Installed Swift Version
 RUN swift --version
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bashrc; \
-    echo -e " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-6.0/centos/7/slim/Dockerfile
+++ b/nightly-6.0/centos/7/slim/Dockerfile
@@ -40,11 +40,12 @@ RUN set -e; \
     && chmod -R o+r /usr/lib/swift /usr/libexec/swift \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bashrc; \
-    echo -e " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-6.0/rhel-ubi/9/Dockerfile
+++ b/nightly-6.0/rhel-ubi/9/Dockerfile
@@ -56,11 +56,12 @@ RUN set -e; \
 # Print Installed Swift Version
 RUN swift --version
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bashrc; \
-    echo -e " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-6.0/rhel-ubi/9/buildx/Dockerfile
+++ b/nightly-6.0/rhel-ubi/9/buildx/Dockerfile
@@ -62,13 +62,14 @@ RUN set -e; \
 # Print Installed Swift Version
 RUN swift --version
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bashrc; \
-    echo -e " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd
 
 RUN echo 'source /etc/bashrc' >> /root/.bashrc

--- a/nightly-6.0/rhel-ubi/9/slim/Dockerfile
+++ b/nightly-6.0/rhel-ubi/9/slim/Dockerfile
@@ -40,11 +40,13 @@ RUN set -e; \
     && chmod -R o+r /usr/lib/swift /usr/libexec/swift \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bashrc; \
-    echo -e " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd
+

--- a/nightly-6.0/ubuntu/20.04/Dockerfile
+++ b/nightly-6.0/ubuntu/20.04/Dockerfile
@@ -67,11 +67,12 @@ RUN set -e; \
 # Print Installed Swift Version
 RUN swift --version
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bash.bashrc; \
-    echo " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bash.bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-6.0/ubuntu/20.04/buildx/Dockerfile
+++ b/nightly-6.0/ubuntu/20.04/buildx/Dockerfile
@@ -73,11 +73,12 @@ RUN set -e; \
 # Print Installed Swift Version
 RUN swift --version
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bash.bashrc; \
-    echo " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bash.bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-6.0/ubuntu/20.04/slim/Dockerfile
+++ b/nightly-6.0/ubuntu/20.04/slim/Dockerfile
@@ -51,11 +51,12 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
     && apt-get purge --auto-remove -y curl gnupg
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bash.bashrc; \
-    echo " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bash.bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-6.0/ubuntu/22.04/Dockerfile
+++ b/nightly-6.0/ubuntu/22.04/Dockerfile
@@ -67,11 +67,12 @@ RUN set -e; \
 # Print Installed Swift Version
 RUN swift --version
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bash.bashrc; \
-    echo " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bash.bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-6.0/ubuntu/22.04/buildx/Dockerfile
+++ b/nightly-6.0/ubuntu/22.04/buildx/Dockerfile
@@ -73,11 +73,12 @@ RUN set -e; \
 # Print Installed Swift Version
 RUN swift --version
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bash.bashrc; \
-    echo " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bash.bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-6.0/ubuntu/22.04/slim/Dockerfile
+++ b/nightly-6.0/ubuntu/22.04/slim/Dockerfile
@@ -51,11 +51,12 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
     && apt-get purge --auto-remove -y curl gnupg
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bash.bashrc; \
-    echo " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bash.bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-main/amazonlinux/2/Dockerfile
+++ b/nightly-main/amazonlinux/2/Dockerfile
@@ -62,13 +62,14 @@ RUN set -e; \
 # Print Installed Swift Version
 RUN swift --version
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bashrc; \
-    echo -e " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd
 
 RUN echo 'source /etc/bashrc' >> /root/.bashrc

--- a/nightly-main/amazonlinux/2/buildx/Dockerfile
+++ b/nightly-main/amazonlinux/2/buildx/Dockerfile
@@ -69,13 +69,14 @@ RUN set -e; \
 # Print Installed Swift Version
 RUN swift --version
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bashrc; \
-    echo -e " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd
 
 RUN echo 'source /etc/bashrc' >> /root/.bashrc

--- a/nightly-main/amazonlinux/2/slim/Dockerfile
+++ b/nightly-main/amazonlinux/2/slim/Dockerfile
@@ -42,13 +42,14 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
     && yum autoremove -y tar gzip
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bashrc; \
-    echo -e " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd
 
 RUN echo 'source /etc/bashrc' >> /root/.bashrc

--- a/nightly-main/centos/7/Dockerfile
+++ b/nightly-main/centos/7/Dockerfile
@@ -84,11 +84,12 @@ RUN ln -s /opt/rh/devtoolset-8/root/usr/lib/gcc/x86_64-redhat-linux/8/libstdc++_
 # Print Installed Swift Version
 RUN swift --version
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bashrc; \
-    echo -e " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-main/centos/7/slim/Dockerfile
+++ b/nightly-main/centos/7/slim/Dockerfile
@@ -40,11 +40,12 @@ RUN set -e; \
     && chmod -R o+r /usr/lib/swift /usr/libexec/swift \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bashrc; \
-    echo -e " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-main/rhel-ubi/9/Dockerfile
+++ b/nightly-main/rhel-ubi/9/Dockerfile
@@ -56,11 +56,12 @@ RUN set -e; \
 # Print Installed Swift Version
 RUN swift --version
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bashrc; \
-    echo -e " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-main/rhel-ubi/9/buildx/Dockerfile
+++ b/nightly-main/rhel-ubi/9/buildx/Dockerfile
@@ -62,13 +62,14 @@ RUN set -e; \
 # Print Installed Swift Version
 RUN swift --version
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bashrc; \
-    echo -e " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd
 
 RUN echo 'source /etc/bashrc' >> /root/.bashrc

--- a/nightly-main/rhel-ubi/9/slim/Dockerfile
+++ b/nightly-main/rhel-ubi/9/slim/Dockerfile
@@ -40,11 +40,12 @@ RUN set -e; \
     && chmod -R o+r /usr/lib/swift /usr/libexec/swift \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bashrc; \
-    echo -e " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-main/ubuntu/18.04/Dockerfile
+++ b/nightly-main/ubuntu/18.04/Dockerfile
@@ -63,11 +63,12 @@ RUN set -e; \
 # Print Installed Swift Version
 RUN swift --version
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bash.bashrc; \
-    echo " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bash.bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-main/ubuntu/18.04/slim/Dockerfile
+++ b/nightly-main/ubuntu/18.04/slim/Dockerfile
@@ -51,11 +51,12 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
     && apt-get purge --auto-remove -y curl gnupg
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bash.bashrc; \
-    echo " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bash.bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-main/ubuntu/20.04/Dockerfile
+++ b/nightly-main/ubuntu/20.04/Dockerfile
@@ -67,11 +67,12 @@ RUN set -e; \
 # Print Installed Swift Version
 RUN swift --version
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bash.bashrc; \
-    echo " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bash.bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-main/ubuntu/20.04/buildx/Dockerfile
+++ b/nightly-main/ubuntu/20.04/buildx/Dockerfile
@@ -73,11 +73,12 @@ RUN set -e; \
 # Print Installed Swift Version
 RUN swift --version
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bash.bashrc; \
-    echo " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bash.bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-main/ubuntu/20.04/slim/Dockerfile
+++ b/nightly-main/ubuntu/20.04/slim/Dockerfile
@@ -51,11 +51,12 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
     && apt-get purge --auto-remove -y curl gnupg
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bash.bashrc; \
-    echo " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bash.bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-main/ubuntu/22.04/Dockerfile
+++ b/nightly-main/ubuntu/22.04/Dockerfile
@@ -67,11 +67,12 @@ RUN set -e; \
 # Print Installed Swift Version
 RUN swift --version
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bash.bashrc; \
-    echo " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bash.bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-main/ubuntu/22.04/buildx/Dockerfile
+++ b/nightly-main/ubuntu/22.04/buildx/Dockerfile
@@ -73,11 +73,12 @@ RUN set -e; \
 # Print Installed Swift Version
 RUN swift --version
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bash.bashrc; \
-    echo " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bash.bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-main/ubuntu/22.04/slim/Dockerfile
+++ b/nightly-main/ubuntu/22.04/slim/Dockerfile
@@ -51,11 +51,12 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
     && apt-get purge --auto-remove -y curl gnupg
 
-RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/motd' \
-    >> /etc/bash.bashrc; \
-    echo " ################################################################\n" \
-    "#\t\t\t\t\t\t\t\t#\n" \
-    "# Swift Nightly Docker Image\t\t\t\t\t#\n" \
-    "# Tag: $(cat .swift_tag)\t\t\t#\n" \
-    "#\t\t\t\t\t\t\t\t#\n"  \
-    "################################################################\n" > /etc/motd
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bash.bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd


### PR DESCRIPTION
The prior tab based padding of the /etc/motd banner lended itself to an error in the padding in length depending on the value of the Swift tag contents. The approach of using `printf` is a bit more friendly from a maintenance perspective.

Lastly, there was a bug in how the bash code was included where the value of `$TERM` wasn't be escaped properly so you'd get a hardcoded value vs. the variable `$TERM`.