### PR TITLE
Install cmake and git test dependencies

### DIFF
--- a/swift-ci/master/fedora/39/Dockerfile
+++ b/swift-ci/master/fedora/39/Dockerfile
@@ -20,6 +20,8 @@ RUN yum install -y \
   clang               \
   perl-podlators      \
   which               \
+  git                 \
+  cmake               \
   diffutils
 
 USER build-user

--- a/swift-ci/master/fedora/40/Dockerfile
+++ b/swift-ci/master/fedora/40/Dockerfile
@@ -20,6 +20,8 @@ RUN yum install -y    \
   clang               \
   perl-podlators      \
   which               \
+  git                 \
+  cmake               \
   diffutils
 
 USER build-user


### PR DESCRIPTION
You can build a complete toolchain without git or CMake installed, but it won't test. build-script builds its own copy of CMake, but doesn't add it to its path for testing purposes, so it'll fail to pass its test suite if you don't pre-install a CMake. The tests also need a pre-installed git to check branch state.

rdar://128502727