### PR TITLE
Swift 5.10: Adding Slim Dockerfiles for new distros

### DIFF
--- a/5.10/debian/12/slim/Dockerfile
+++ b/5.10/debian/12/slim/Dockerfile
@@ -1,0 +1,58 @@
+FROM debian:12
+LABEL maintainer="Swift Infrastructure <swift-infrastructure@forums.swift.org>"
+LABEL description="Docker Container for the Swift programming language"
+
+RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
+    apt-get -q install -y \
+    libcurl4 \
+    libxml2 \
+    tzdata \
+    && rm -r /var/lib/apt/lists/*
+
+# Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little
+
+# pub   4096R/ED3D1561 2019-03-22 [SC] [expires: 2023-03-23]
+#       Key fingerprint = A62A E125 BBBF BB96 A6E0  42EC 925C C1CC ED3D 1561
+# uid                  Swift 5.x Release Signing Key <swift-infrastructure@swift.org
+ARG SWIFT_SIGNING_KEY=A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
+ARG SWIFT_PLATFORM=debian12
+ARG SWIFT_BRANCH=swift-5.10.1-release
+ARG SWIFT_VERSION=swift-5.10.1-RELEASE
+ARG SWIFT_WEBROOT=https://download.swift.org
+
+ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
+    SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    SWIFT_BRANCH=$SWIFT_BRANCH \
+    SWIFT_VERSION=$SWIFT_VERSION \
+    SWIFT_WEBROOT=$SWIFT_WEBROOT
+
+RUN set -e; \
+    ARCH_NAME="$(dpkg --print-architecture)"; \
+    url=; \
+    case "${ARCH_NAME##*-}" in \
+        'amd64') \
+            OS_ARCH_SUFFIX=''; \
+            ;; \
+        'arm64') \
+            OS_ARCH_SUFFIX='-aarch64'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture: '$ARCH_NAME'"; exit 1 ;; \
+    esac; \
+    SWIFT_WEBDIR="$SWIFT_WEBROOT/$SWIFT_BRANCH/$(echo $SWIFT_PLATFORM | tr -d .)$OS_ARCH_SUFFIX" \
+    && SWIFT_BIN_URL="$SWIFT_WEBDIR/$SWIFT_VERSION/$SWIFT_VERSION-$SWIFT_PLATFORM$OS_ARCH_SUFFIX.tar.gz" \
+    && SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
+    # - Grab curl and gpg here so we cache better up above
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -q update && apt-get -q install -y curl gpg && rm -rf /var/lib/apt/lists/* \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \
+    && gpg --batch --quiet --keyserver keyserver.ubuntu.com --recv-keys "$SWIFT_SIGNING_KEY" \
+    && gpg --batch --verify swift.tar.gz.sig swift.tar.gz \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && tar -xzf swift.tar.gz --directory / --strip-components=1 \
+        $SWIFT_VERSION-$SWIFT_PLATFORM$OS_ARCH_SUFFIX/usr/lib/swift/linux \
+        $SWIFT_VERSION-$SWIFT_PLATFORM$OS_ARCH_SUFFIX/usr/libexec/swift/linux \
+    && chmod -R o+r /usr/lib/swift /usr/libexec/swift \
+    && rm -rf "$GNUPGHOME" swift.tar.gz.sig swift.tar.gz \
+    && apt-get purge --auto-remove -y curl gpg

--- a/5.10/fedora/39/slim/Dockerfile
+++ b/5.10/fedora/39/slim/Dockerfile
@@ -1,0 +1,48 @@
+FROM fedora:39
+
+LABEL maintainer="Swift Infrastructure <swift-infrastructure@forums.swift.org>"
+LABEL description="Docker Container for the Swift programming language"
+
+# Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little
+
+# pub   4096R/ED3D1561 2019-03-22 [SC] [expires: 2023-03-23]
+#       Key fingerprint = A62A E125 BBBF BB96 A6E0  42EC 925C C1CC ED3D 1561
+# uid                  Swift 5.x Release Signing Key <swift-infrastructure@swift.org
+ARG SWIFT_SIGNING_KEY=A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
+ARG SWIFT_PLATFORM=fedora39
+ARG SWIFT_BRANCH=swift-5.10.1-release
+ARG SWIFT_VERSION=swift-5.10.1-RELEASE
+ARG SWIFT_WEBROOT=https://download.swift.org
+
+ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
+    SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    SWIFT_BRANCH=$SWIFT_BRANCH \
+    SWIFT_VERSION=$SWIFT_VERSION \
+    SWIFT_WEBROOT=$SWIFT_WEBROOT
+
+RUN set -ex; \
+    ARCH_NAME="$(rpm --eval '%{_arch}')"; \
+    url=; \
+    case "${ARCH_NAME##*-}" in \
+        'x86_64') \
+            OS_ARCH_SUFFIX=''; \
+            ;; \
+        'aarch64') \
+            OS_ARCH_SUFFIX='-aarch64'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture: '$ARCH_NAME'"; exit 1 ;; \
+    esac; \
+    SWIFT_WEBDIR="$SWIFT_WEBROOT/$SWIFT_BRANCH/$(echo $SWIFT_PLATFORM | tr -d .)$OS_ARCH_SUFFIX" \
+    && SWIFT_BIN_URL="$SWIFT_WEBDIR/$SWIFT_VERSION/$SWIFT_VERSION-$SWIFT_PLATFORM$OS_ARCH_SUFFIX.tar.gz" \
+    && SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \
+    && gpg --batch --quiet --keyserver keyserver.ubuntu.com --recv-keys "$SWIFT_SIGNING_KEY" \
+    && gpg --batch --verify swift.tar.gz.sig swift.tar.gz \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && tar -xzf swift.tar.gz --directory / --strip-components=1 \
+        $SWIFT_VERSION-$SWIFT_PLATFORM$OS_ARCH_SUFFIX/usr/lib/swift/linux \
+        $SWIFT_VERSION-$SWIFT_PLATFORM$OS_ARCH_SUFFIX/usr/libexec/swift/linux \
+    && chmod -R o+r /usr/lib/swift /usr/libexec/swift \
+    && rm -rf "$GNUPGHOME" swift.tar.gz.sig swift.tar.gz

--- a/5.10/ubuntu/23.10/slim/Dockerfile
+++ b/5.10/ubuntu/23.10/slim/Dockerfile
@@ -1,0 +1,59 @@
+FROM ubuntu:23.10
+
+LABEL maintainer="Swift Infrastructure <swift-infrastructure@forums.swift.org>"
+LABEL description="Docker Container for the Swift programming language"
+
+RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
+    apt-get -q install -y \
+    libcurl4 \
+    libxml2 \
+    tzdata \
+    && rm -r /var/lib/apt/lists/*
+
+# Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little
+
+# pub   4096R/ED3D1561 2019-03-22 [SC] [expires: 2023-03-23]
+#       Key fingerprint = A62A E125 BBBF BB96 A6E0  42EC 925C C1CC ED3D 1561
+# uid                  Swift 5.x Release Signing Key <swift-infrastructure@swift.org
+ARG SWIFT_SIGNING_KEY=A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
+ARG SWIFT_PLATFORM=ubuntu23.10
+ARG SWIFT_BRANCH=swift-5.10.1-release
+ARG SWIFT_VERSION=swift-5.10.1-RELEASE
+ARG SWIFT_WEBROOT=https://download.swift.org
+
+ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
+    SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    SWIFT_BRANCH=$SWIFT_BRANCH \
+    SWIFT_VERSION=$SWIFT_VERSION \
+    SWIFT_WEBROOT=$SWIFT_WEBROOT
+
+RUN set -e; \
+    ARCH_NAME="$(dpkg --print-architecture)"; \
+    url=; \
+    case "${ARCH_NAME##*-}" in \
+        'amd64') \
+            OS_ARCH_SUFFIX=''; \
+            ;; \
+        'arm64') \
+            OS_ARCH_SUFFIX='-aarch64'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture: '$ARCH_NAME'"; exit 1 ;; \
+    esac; \
+    SWIFT_WEBDIR="$SWIFT_WEBROOT/$SWIFT_BRANCH/$(echo $SWIFT_PLATFORM | tr -d .)$OS_ARCH_SUFFIX" \
+    && SWIFT_BIN_URL="$SWIFT_WEBDIR/$SWIFT_VERSION/$SWIFT_VERSION-$SWIFT_PLATFORM$OS_ARCH_SUFFIX.tar.gz" \
+    && SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
+    # - Grab curl and gpg here so we cache better up above
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -q update && apt-get -q install -y curl gnupg && rm -rf /var/lib/apt/lists/* \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \
+    && gpg --batch --quiet --keyserver keyserver.ubuntu.com --recv-keys "$SWIFT_SIGNING_KEY" \
+    && gpg --batch --verify swift.tar.gz.sig swift.tar.gz \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && tar -xzf swift.tar.gz --directory / --strip-components=1 \
+        $SWIFT_VERSION-$SWIFT_PLATFORM$OS_ARCH_SUFFIX/usr/lib/swift/linux \
+        $SWIFT_VERSION-$SWIFT_PLATFORM$OS_ARCH_SUFFIX/usr/libexec/swift/linux \
+    && chmod -R o+r /usr/lib/swift /usr/libexec/swift \
+    && rm -rf "$GNUPGHOME" swift.tar.gz.sig swift.tar.gz \
+    && apt-get purge --auto-remove -y curl gnupg

--- a/5.10/ubuntu/24.04/slim/Dockerfile
+++ b/5.10/ubuntu/24.04/slim/Dockerfile
@@ -1,0 +1,59 @@
+FROM ubuntu:24.04
+
+LABEL maintainer="Swift Infrastructure <swift-infrastructure@forums.swift.org>"
+LABEL description="Docker Container for the Swift programming language"
+
+RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
+    apt-get -q install -y \
+    libcurl4 \
+    libxml2 \
+    tzdata \
+    && rm -r /var/lib/apt/lists/*
+
+# Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little
+
+# pub   4096R/ED3D1561 2019-03-22 [SC] [expires: 2023-03-23]
+#       Key fingerprint = A62A E125 BBBF BB96 A6E0  42EC 925C C1CC ED3D 1561
+# uid                  Swift 5.x Release Signing Key <swift-infrastructure@swift.org
+ARG SWIFT_SIGNING_KEY=A62AE125BBBFBB96A6E042EC925CC1CCED3D1561
+ARG SWIFT_PLATFORM=ubuntu24.04
+ARG SWIFT_BRANCH=swift-5.10.1-release
+ARG SWIFT_VERSION=swift-5.10.1-RELEASE
+ARG SWIFT_WEBROOT=https://download.swift.org
+
+ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
+    SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    SWIFT_BRANCH=$SWIFT_BRANCH \
+    SWIFT_VERSION=$SWIFT_VERSION \
+    SWIFT_WEBROOT=$SWIFT_WEBROOT
+
+RUN set -e; \
+    ARCH_NAME="$(dpkg --print-architecture)"; \
+    url=; \
+    case "${ARCH_NAME##*-}" in \
+        'amd64') \
+            OS_ARCH_SUFFIX=''; \
+            ;; \
+        'arm64') \
+            OS_ARCH_SUFFIX='-aarch64'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture: '$ARCH_NAME'"; exit 1 ;; \
+    esac; \
+    SWIFT_WEBDIR="$SWIFT_WEBROOT/$SWIFT_BRANCH/$(echo $SWIFT_PLATFORM | tr -d .)$OS_ARCH_SUFFIX" \
+    && SWIFT_BIN_URL="$SWIFT_WEBDIR/$SWIFT_VERSION/$SWIFT_VERSION-$SWIFT_PLATFORM$OS_ARCH_SUFFIX.tar.gz" \
+    && SWIFT_SIG_URL="$SWIFT_BIN_URL.sig" \
+    # - Grab curl and gpg here so we cache better up above
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -q update && apt-get -q install -y curl gnupg && rm -rf /var/lib/apt/lists/* \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fsSL "$SWIFT_BIN_URL" -o swift.tar.gz "$SWIFT_SIG_URL" -o swift.tar.gz.sig \
+    && gpg --batch --quiet --keyserver keyserver.ubuntu.com --recv-keys "$SWIFT_SIGNING_KEY" \
+    && gpg --batch --verify swift.tar.gz.sig swift.tar.gz \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && tar -xzf swift.tar.gz --directory / --strip-components=1 \
+        $SWIFT_VERSION-$SWIFT_PLATFORM$OS_ARCH_SUFFIX/usr/lib/swift/linux \
+        $SWIFT_VERSION-$SWIFT_PLATFORM$OS_ARCH_SUFFIX/usr/libexec/swift/linux \
+    && chmod -R o+r /usr/lib/swift /usr/libexec/swift \
+    && rm -rf "$GNUPGHOME" swift.tar.gz.sig swift.tar.gz \
+    && apt-get purge --auto-remove -y curl gnupg


### PR DESCRIPTION
Adding new Swift 5.10 slim Dockerfiles
 - Ubuntu 24.04
 - Ubuntu 23.10
 - Fedora 39
 - Debian 12