### PR TITLE
[Static Linux SDK] Enable gzipping of the tarball.

### DIFF
--- a/swift-ci/sdks/static-linux/scripts/build.sh
+++ b/swift-ci/sdks/static-linux/scripts/build.sh
@@ -912,6 +912,6 @@ header "Outputting compressed bundle"
 
 quiet_pushd "${build_dir}"
 mkdir -p "${products_dir}"
-tar cvf "${products_dir}/${bundle}.tar.gz" "${bundle}"
+tar cvzf "${products_dir}/${bundle}.tar.gz" "${bundle}"
 quiet_popd
 


### PR DESCRIPTION
Seems I missed off a `z` from the `tar` command.