### PR TITLE
Add Swift PATH to /etc/profile for Debian 12

### DIFF
--- a/swift-ci/master/debian/12/Dockerfile
+++ b/swift-ci/master/debian/12/Dockerfile
@@ -78,6 +78,8 @@ RUN set -e; \
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
 
+RUN echo PATH="${SWIFT_PREFIX}/usr/bin:${PATH}" >> /etc/profile
+
 USER build-user
 
 WORKDIR /home/build-user


### PR DESCRIPTION
CI builds for Debian 12 are consistently failing at the same point.

The issue is being caused by being unable to find the host Swift install for bootstrapping.
See build logs -
`-- Warning: {} Host toolchain could not locate a compiler to build swift-driver. `

This problem seems to be unique to Debian Docker containers being started via `ssh` e.g. a Jenkins pipeline build.
When the container is started via `ssh` the saved `env PATH` is overwritten.

The solution is to add the PATH to `/etc/profile`