### PR TITLE
[Swift-6.0-nightly] Add missing python libs for AL2

### DIFF
--- a/nightly-6.0/amazonlinux/2/Dockerfile
+++ b/nightly-6.0/amazonlinux/2/Dockerfile
@@ -17,6 +17,7 @@ RUN yum -y install \
   libuuid \
   libxml2-devel \
   openssl-devel \
+  python3-libs \
   tar \
   tzdata \
   unzip \


### PR DESCRIPTION
The Swift REPL requires that the python libraries are available or it will fail to launch. Adding the missing dependency on AmazonLinux 2.