### PR TITLE
add note about nightly image tags to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 #### You can find the Docker Hub repo here: [https://hub.docker.com/_/swift/](https://hub.docker.com/_/swift/)
 
+#### Nightly image tags are published here: [https://hub.docker.com/r/swiftlang/swift](https://hub.docker.com/r/swiftlang/swift)
+
 
 ### Usage
 


### PR DESCRIPTION
I was trying to find the nightly Docker tags and forgot that they were published to a different Docker repo. This PR adds a blurb to the readme that references the `swiftlang/swift` Docker repo where the nightly tags are published.