### PR TITLE
Install libc++ package on CI images of Ubuntu 22.04

### DIFF
--- a/swift-ci/master/ubuntu/22.04/Dockerfile
+++ b/swift-ci/master/ubuntu/22.04/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get -y update && apt-get -y install \
   file                  \
   git                   \
   icu-devtools          \
+  libc++-15-dev         \
   libcurl4-openssl-dev  \
   libedit-dev           \
   libicu-dev            \


### PR DESCRIPTION
This adds a `libc++-15-dev` package to the list of packages installed on a CI image of Ubuntu 22.04.

https://packages.ubuntu.com/jammy/libc++-15-dev

Swift/C++ interoperability will soon allow compiling with a C++ standard library that is not the default on the particular platform, e.g. with libc++ on Linux. Having the libc++ package installed in Swift CI allows us to run compiler tests for this new functionality.

rdar://118357548 / https://github.com/swiftlang/swift/issues/69825