### PR TITLE
Make sure libc++abi is installed along with libc++

### DIFF
--- a/swift-ci/master/ubuntu/22.04/Dockerfile
+++ b/swift-ci/master/ubuntu/22.04/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get -y update && apt-get -y install \
   git                   \
   icu-devtools          \
   libc++-15-dev         \
+  libc++abi-15-dev      \
   libcurl4-openssl-dev  \
   libedit-dev           \
   libicu-dev            \


### PR DESCRIPTION
This is a follow-up to https://github.com/swiftlang/swift-docker/pull/402.

This fixes Swift CI test failures:
```
/usr/bin/ld.gold: error: cannot find -lc++abi
```