### PR TITLE
Install python3-pip in ubuntu and AWS container

### DIFF
--- a/swift-ci/main/amazon-linux/2/Dockerfile
+++ b/swift-ci/main/amazon-linux/2/Dockerfile
@@ -6,8 +6,7 @@ RUN groupadd -g 998 build-user && \
     useradd -m -r -u 42 -g build-user build-user
 
 # The build needs a package from the EPEL repo so that needs to be enabled.
-# https://www.tecmint.com/install-epel-repository-on-centos/
-RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+RUN amazon-linux-extras install epel -y
 
 # Update and install needed build packages
 RUN yum -y group install "development tools"

--- a/swift-ci/main/amazon-linux/2/Dockerfile
+++ b/swift-ci/main/amazon-linux/2/Dockerfile
@@ -30,6 +30,7 @@ RUN yum -y install \
   python-devel     \
   python-pkgconfig \
   python-six       \
+  python3-pip      \
   python3-devel    \
   python3-psutil   \
   rsync            \

--- a/swift-ci/main/ubuntu/18.04/Dockerfile
+++ b/swift-ci/main/ubuntu/18.04/Dockerfile
@@ -23,6 +23,7 @@ RUN apt -y update && apt -y install \
   python-six            \
   python-pkg-resources  \
   python3-six           \
+  python3-pip           \
   python3-distutils     \
   python3-pkg-resources \
   python3-psutil        \

--- a/swift-ci/main/ubuntu/20.04/Dockerfile
+++ b/swift-ci/main/ubuntu/20.04/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get -y update && apt-get -y install \
   python-six            \
   python2-dev           \
   python3-six           \
+  python3-pip           \
   python3-distutils     \
   python3-pkg-resources \
   python3-psutil        \

--- a/swift-ci/main/ubuntu/22.04/Dockerfile
+++ b/swift-ci/main/ubuntu/22.04/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get -y update && apt-get -y install \
   python-six            \
   python2-dev           \
   python3-six           \
+  python3-pip           \
   python3-distutils     \
   python3-pkg-resources \
   python3-psutil        \

--- a/swift-ci/main/ubuntu/23.10/Dockerfile
+++ b/swift-ci/main/ubuntu/23.10/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get -y update && apt-get -y install \
   ninja-build           \
   pkg-config            \
   python3-six           \
+  python3-pip           \
   python3-distutils     \
   python3-pkg-resources \
   python3-psutil        \

--- a/swift-ci/main/ubuntu/24.04/Dockerfile
+++ b/swift-ci/main/ubuntu/24.04/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get -y update && apt-get -y install \
   ninja-build           \
   pkg-config            \
   python3-six           \
+  python3-pip           \
   python3-pkg-resources \
   python3-psutil        \
   python3-setuptools    \


### PR DESCRIPTION
Install python3 pip in the nightly containers so the rebranch jobs can install their dependencies