### PR TITLE
[Static Linux SDK] Build script improvements.

### DIFF
--- a/swift-ci/sdks/static-linux/Dockerfile
+++ b/swift-ci/sdks/static-linux/Dockerfile
@@ -24,6 +24,9 @@ ARG BORINGSSL_VERSION=fips-20220613
 ARG ICU_VERSION=maint/maint-69
 ARG ZLIB_VERSION=1.3.1
 
+# Architecture to build on (empty means x86-64)
+ARG OS_ARCH_SUFFIX=
+
 # ............................................................................
 
 # Install development tools
@@ -62,7 +65,7 @@ ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
     OS_MAJOR_VER=$OS_MAJOR_VER \
     OS_MINOR_VER=$OS_MINOR_VER \
     OS_VER=$SWIFT_PLATFORM$OS_MAJOR_VER.$OS_MINOR_VER \
-    SWIFT_WEBROOT="$SWIFT_WEBROOT/$SWIFT_PLATFORM$OS_MAJOR_VER$OS_MINOR_VER"
+    SWIFT_WEBROOT="$SWIFT_WEBROOT/$SWIFT_PLATFORM$OS_MAJOR_VER$OS_MINOR_VER$OS_ARCH_SUFFIX"
 
 COPY scripts/install-swift.sh /scripts/install-swift.sh
 RUN chmod ugo+x /scripts/install-swift.sh

--- a/swift-ci/sdks/static-linux/build
+++ b/swift-ci/sdks/static-linux/build
@@ -14,10 +14,25 @@
 #
 # ===----------------------------------------------------------------------===
 
-DOCKER=docker
+if [[ "$DOCKER" == "" ]]; then
+    DOCKER=docker
+fi
+
+case $(arch) in
+    arm64|aarch64)
+        OS_ARCH_SUFFIX=-aarch64
+        ;;
+    amd64|x86_64)
+        OS_ARCH_SUFFIX=
+        ;;
+    *)
+        echo "Unknown architecture $(arch)"
+        exit 1
+        ;;
+esac
 
 # Build the Docker image
-$(DOCKER) build -t static-swift-linux .
+$DOCKER build --build-arg OS_ARCH_SUFFIX=$OS_ARCH_SUFFIX -t static-swift-linux .
 
 # Check-out the sources
 scripts/fetch-source.sh --clone-with-ssh --source-dir source
@@ -25,7 +40,7 @@ scripts/fetch-source.sh --clone-with-ssh --source-dir source
 mkdir -p products
 
 # Run the build
-$(DOCKER) run -it --rm \
+$DOCKER run -it --rm \
           -v ./source:/source \
           -v ./products:/products \
           static-swift-linux \

--- a/swift-ci/sdks/static-linux/scripts/build.sh
+++ b/swift-ci/sdks/static-linux/scripts/build.sh
@@ -144,6 +144,20 @@ while [ "$#" -gt 0 ]; do
     shift
 done
 
+# Work out the host architecture
+case $(arch) in
+    arm64|aarch64)
+        host_arch=arm64
+        ;;
+    amd64|x86_64)
+        host_arch=x86_64
+        ;;
+    *)
+        echo "Unknown host architecture $(arch)"
+        exit 1
+        ;;
+esac
+
 # Change the commas for spaces
 archs="${archs//,/ }"
 
@@ -662,7 +676,7 @@ EOF
         --compiler-vendor=apple \
         --bootstrapping hosttools \
         --build-linux-static --install-swift \
-        --stdlib-deployment-targets linux-x86_64,linux-static-$arch \
+        --stdlib-deployment-targets linux-$host_arch,linux-static-$arch \
         --build-stdlib-deployment-targets all \
         --musl-path=${build_dir}/sdk_root \
         --linux-static-arch=$arch \
@@ -724,6 +738,7 @@ EOF
           -DFOUNDATION_PATH_TO_LIBDISPATCH_BUILD=${build_dir}/$arch/dispatch \
           -D_SwiftFoundation_SourceDIR=${source_dir}/swift-project/swift-foundation \
           -D_SwiftFoundationICU_SourceDIR=${source_dir}/swift-project/swift-foundation-icu \
+          -D_SwiftCollections_SourceDIR=${source_dir}/swift-project/swift-collections \
           -DCMAKE_Swift_COMPILER_WORKS=YES \
           -Ddispatch_DIR=${build_dir}/$arch/dispatch/cmake/modules
 

--- a/swift-ci/sdks/static-linux/scripts/fetch-source.sh
+++ b/swift-ci/sdks/static-linux/scripts/fetch-source.sh
@@ -164,7 +164,7 @@ cd swift
 # Get its dependencies
 header "Fetching Swift Dependencies"
 
-extra_args=--skip-history
+extra_args="--skip-history --all-repositories"
 if [[ $SWIFT_VERSION == scheme:* ]]; then
     utils/update-checkout ${clone_arg} --scheme ${SWIFT_VERSION#scheme:} ${extra_args}
 elif [[ $SWIFT_VERSION == tag:* ]]; then


### PR DESCRIPTION
When running on an aarch64 host, we need to download a different version of the Swift compiler in order to do the build.  If we run the build on a macOS host, we also have to tell the update-checkout script to fetch all the required dependencies (even Linux-only ones).

Also tell Foundation where swift-collections lives, to avoid it fetching another copy.