### PR TITLE
[Static SDK] Don't build FoundationMacros.

### DIFF
--- a/swift-ci/sdks/static-linux/scripts/build.sh
+++ b/swift-ci/sdks/static-linux/scripts/build.sh
@@ -739,6 +739,7 @@ EOF
           -D_SwiftFoundation_SourceDIR=${source_dir}/swift-project/swift-foundation \
           -D_SwiftFoundationICU_SourceDIR=${source_dir}/swift-project/swift-foundation-icu \
           -D_SwiftCollections_SourceDIR=${source_dir}/swift-project/swift-collections \
+          -DSwiftFoundation_MACRO=/usr/local/swift/lib/swift/host/plugins/libFoundationMacros.so
           -DCMAKE_Swift_COMPILER_WORKS=YES \
           -Ddispatch_DIR=${build_dir}/$arch/dispatch/cmake/modules
 


### PR DESCRIPTION
We don't want to be trying to build FoundationMacros here.  Instead, just use the one that comes with the compiler we installed.

rdar://136278412