### PR TITLE
Install libc++ package on CI images of Ubuntu 24.04

### DIFF
--- a/swift-ci/main/ubuntu/24.04/Dockerfile
+++ b/swift-ci/main/ubuntu/24.04/Dockerfile
@@ -11,6 +11,8 @@ RUN apt-get -y update && apt-get -y install \
   cmake                 \
   git                   \
   icu-devtools          \
+  libc++-18-dev         \
+  libc++abi-18-dev      \
   libcurl4-openssl-dev  \
   libedit-dev           \
   libicu-dev            \


### PR DESCRIPTION
This adds a `libc++-18-dev` package to the list of packages installed on a CI image of Ubuntu 24.04.

Swift is now capable of compiling code that uses C++ interop with libc++ on Linux. Having the libc++ package installed provides us with CI coverage of the feature.

This is similar to https://github.com/swiftlang/swift-docker/pull/402.