### PR TITLE
Adding the base image for AmazonLinux 2023

### DIFF
--- a/swift-ci/main/amazon-linux/2023/Dockerfile
+++ b/swift-ci/main/amazon-linux/2023/Dockerfile
@@ -1,0 +1,41 @@
+FROM amazonlinux:2023
+
+RUN yum install shadow-utils -y
+
+RUN groupadd -g 998 build-user && \
+    useradd -m -r -u 42 -g build-user build-user
+
+RUN yum -y group install "development tools"
+RUN yum -y install \
+  cmake \
+  ninja-build \
+  curl-devel \
+  gcc-c++ \
+  clang \
+  git \
+  libbsd-devel \
+  libedit-devel \
+  libicu-devel \
+  libuuid-devel \
+  libxml2-devel \
+  ncurses-devel \
+  pkgconfig \
+  procps-ng \
+  python3 \
+  python3-devel \
+  python3-distro \
+  python3-setuptools \
+  rsync \
+  sqlite-devel \
+  swig \
+  tzdata \
+  unzip \
+  zip \
+  lld \
+  diffutils
+
+
+# TODO: Still need to install bits for lldb
+
+USER build-user
+WORKDIR /home/build-user


### PR DESCRIPTION
Adding a base image for building Swift for AmazonLinux 2023. This installs the minimally required dependencies for building the compiler and runtime libraries.