### PR TITLE
Add missing system packages needed for C++ on Debian 12, Fedora 39

### DIFF
--- a/5.10/debian/12/Dockerfile
+++ b/5.10/debian/12/Dockerfile
@@ -18,6 +18,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     tzdata \
     git \
     gcc \
+    libstdc++-12-dev \
     && rm -r /var/lib/apt/lists/*
 
 # Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little

--- a/5.10/fedora/39/Dockerfile
+++ b/5.10/fedora/39/Dockerfile
@@ -14,7 +14,9 @@ RUN yum -y install \
   sqlite-devel \
   libuuid-devel \
   libxml2-devel \
-  python3-devel
+  python3-devel \
+  libstdc++-devel \
+  libstdc++-static
 
 # Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little
 

--- a/6.0/debian/12/Dockerfile
+++ b/6.0/debian/12/Dockerfile
@@ -18,6 +18,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     tzdata \
     git \
     gcc \
+    libstdc++-12-dev \
     && rm -r /var/lib/apt/lists/*
 
 # Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little

--- a/6.0/fedora/39/Dockerfile
+++ b/6.0/fedora/39/Dockerfile
@@ -14,7 +14,9 @@ RUN yum -y install \
   sqlite-devel \
   libuuid-devel \
   libxml2-devel \
-  python3-devel
+  python3-devel \
+  libstdc++-devel \
+  libstdc++-static
 
 # Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little
 

--- a/swift-ci/main/debian/12/Dockerfile
+++ b/swift-ci/main/debian/12/Dockerfile
@@ -30,7 +30,8 @@ RUN apt-get -y update && apt-get -y install \
   systemtap-sdt-dev     \
   tzdata                \
   uuid-dev              \
-  zip
+  zip                   \
+  libstdc++-12-dev
 
 
 ARG SWIFT_PLATFORM=debian12

--- a/swift-ci/main/fedora/39/Dockerfile
+++ b/swift-ci/main/fedora/39/Dockerfile
@@ -25,7 +25,9 @@ RUN yum install -y \
   cmake               \
   zip                 \
   unzip               \
-  diffutils
+  diffutils           \
+  libstdc++-devel     \
+  libstdc++-static
 
 ARG SWIFT_PLATFORM=fedora39
 ARG SWIFT_VERSION=5.10.1


### PR DESCRIPTION
While compiling swiftly on these new platforms there were missing headers and archives for Debian 12 and Fedora 39. Add these packages so that if the container is used to compile and link C++ code the necessary headers and archives are present.