### PR TITLE
Update Dockerfile

### DIFF
--- a/6.0/ubuntu/24.04/Dockerfile
+++ b/6.0/ubuntu/24.04/Dockerfile
@@ -14,6 +14,7 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     libgcc-13-dev \
     libpython3-dev \
     libsqlite3-0 \
+    libsqlite3-dev \
     libstdc++-13-dev \
     libxml2-dev \
     libncurses-dev \


### PR DESCRIPTION

![Screenshot from 2025-02-03 16-12-37](https://github.com/user-attachments/assets/ff61674a-3751-4dcc-a006-a39361e8a4f9)
it solves the compile error of :102.5 /source/.build/checkouts/swift-llbuild/lib/Core/SQLiteBuildDB.cpp:28:10: fatal error: 'sqlite3.h' file not found
102.5    28 | #include <sqlite3.h>
102.5       |          ^~~~~~~~~~~

 In Ubuntu, you need to install libsqlite3-dev (in addition to the runtime package libsqlite3-0) so that the header files are available for compilation. Therefore, adding `libsqlite3-dev` resolves the error