### PR TITLE
Add static packages to enable -static-executable test.

### DIFF
--- a/nightly-main/rhel-ubi/9/Dockerfile
+++ b/nightly-main/rhel-ubi/9/Dockerfile
@@ -6,8 +6,11 @@ LABEL description="Docker Container for the Swift programming language"
 RUN yum install -y  \
   git               \
   gcc-c++           \
+  glibc-static      \
   libcurl-devel     \
   libedit-devel     \
+  libstdc++-devel   \
+  libstdc++-static  \
   libuuid-devel     \
   libxml2-devel     \
   ncurses-devel     \

--- a/swift-ci/main/amazon-linux/2023/Dockerfile
+++ b/swift-ci/main/amazon-linux/2023/Dockerfile
@@ -13,9 +13,11 @@ RUN yum -y install \
   gcc-c++ \
   clang \
   git \
+  glibc-static \
   libbsd-devel \
   libedit-devel \
   libicu-devel \
+  libstdc++-static \
   libuuid-devel \
   libxml2-devel \
   ncurses-devel \

--- a/swift-ci/main/fedora/39/Dockerfile
+++ b/swift-ci/main/fedora/39/Dockerfile
@@ -27,7 +27,8 @@ RUN yum install -y \
   unzip               \
   diffutils           \
   libstdc++-devel     \
-  libstdc++-static
+  libstdc++-static    \
+  glibc-static
 
 ARG SWIFT_PLATFORM=fedora39
 ARG SWIFT_VERSION=5.10.1

--- a/swift-ci/main/fedora/40/Dockerfile
+++ b/swift-ci/main/fedora/40/Dockerfile
@@ -25,7 +25,11 @@ RUN yum install -y    \
   cmake               \
   zip                 \
   unzip               \
-  diffutils
+  diffutils           \
+  libstdc++-devel     \
+  libstdc++-static    \
+  glibc-static
+
 
 COPY swift-ci/dependencies/requirements.txt /dependencies/
 RUN pip3 install -r /dependencies/requirements.txt

--- a/swift-ci/main/fedora/41/Dockerfile
+++ b/swift-ci/main/fedora/41/Dockerfile
@@ -30,6 +30,7 @@ RUN yum install -y \
   libstdc++-static    \
   ninja-build         \
   gnupg               \
+  glibc-static        \
   binutils-gold
 
 ARG SWIFT_PLATFORM=fedora39

--- a/swift-ci/main/rhel-ubi/8/Dockerfile
+++ b/swift-ci/main/rhel-ubi/8/Dockerfile
@@ -8,10 +8,13 @@ RUN yum install -y  \
   gcc-c++           \
   clang             \
   cmake             \
+  glibc-static      \
   make              \
   libcurl-devel     \
   libedit-devel     \
   libuuid-devel     \
+  libstdc++-devel   \
+  libstdc++-static  \
   libxml2-devel     \
   ncurses-devel     \
   python3-devel     \

--- a/swift-ci/main/rhel-ubi/9/Dockerfile
+++ b/swift-ci/main/rhel-ubi/9/Dockerfile
@@ -6,11 +6,14 @@ RUN groupadd -g 42 build-user && \
 RUN yum install -y  \
   git               \
   gcc-c++           \
+  glibc-static      \
   cmake             \
   diffutils         \
   make              \
   libcurl-devel     \
   libedit-devel     \
+  libstdc++-devel   \
+  libstdc++-static  \
   libuuid-devel     \
   libxml2-devel     \
   ncurses-devel     \


### PR DESCRIPTION
Allows for a -static-executable test to be re-enabled.

See https://github.com/swiftlang/swift/pull/79637