### PR TITLE
Create Ubuntu 24.04 Bootstrap Environment

### DIFF
--- a/swift-ci/main/ubuntu/24.04/Bootstrap/Dockerfile
+++ b/swift-ci/main/ubuntu/24.04/Bootstrap/Dockerfile
@@ -1,0 +1,43 @@
+FROM ubuntu:24.04
+
+ARG BUILD_USER_ID=998
+
+RUN groupadd -g ${BUILD_USER_ID} build-user && \
+    useradd -m -r -u ${BUILD_USER_ID} -g build-user build-user
+
+ENV DEBIAN_FRONTEND="noninteractive"
+
+RUN apt-get -y update && apt-get -y install \
+  build-essential       \
+  clang                 \
+  cmake                 \
+  git                   \
+  icu-devtools          \
+  libc++-18-dev         \
+  libc++abi-18-dev      \
+  libcurl4-openssl-dev  \
+  libedit-dev           \
+  libicu-dev            \
+  libncurses5-dev       \
+  libpython3-dev        \
+  libsqlite3-dev        \
+  libxml2-dev           \
+  ninja-build           \
+  pkg-config            \
+  python3-six           \
+  python3-pip           \
+  python3-pkg-resources \
+  python3-psutil        \
+  python3-setuptools    \
+  rsync                 \
+  swig                  \
+  systemtap-sdt-dev     \
+  tzdata                \
+  uuid-dev              \
+  zip
+
+COPY swift-ci/dependencies/requirements.txt /dependencies/
+RUN pip3 install -r /dependencies/requirements.txt --break-system-packages
+
+USER build-user
+WORKDIR /home/build-user


### PR DESCRIPTION
This docker image produces an environment with all of the required dependencies for building a full Swift toolchain, but without installing an existing Swift toolchain. This is to provide an environment for testing the bootstrap process.