### PR TITLE
Update nightly platforms

### DIFF
--- a/nightly-6.1/debian/12/Dockerfile
+++ b/nightly-6.1/debian/12/Dockerfile
@@ -1,0 +1,89 @@
+FROM debian:12
+
+RUN groupadd -g 998 build-user && \
+    useradd -m -r -u 998 -g build-user build-user
+
+ENV DEBIAN_FRONTEND="noninteractive"
+
+RUN apt-get -y update && apt-get -y install \
+  build-essential       \
+  clang                 \
+  cmake                 \
+  diffutils             \
+  git                   \
+  icu-devtools          \
+  libcurl4-openssl-dev  \
+  libedit-dev           \
+  libicu-dev            \
+  libncurses-dev        \
+  libpython3-dev        \
+  libsqlite3-dev        \
+  libxml2-dev           \
+  ninja-build           \
+  pkg-config            \
+  python3-distutils     \
+  python3-pip           \
+  python3-pkg-resources \
+  python3-psutil        \
+  rsync                 \
+  swig                  \
+  systemtap-sdt-dev     \
+  tzdata                \
+  uuid-dev              \
+  zip                   \
+  libstdc++-12-dev
+
+
+ARG SWIFT_SIGNING_KEY=E813C892820A6FA13755B268F167DF1ACF9CE069
+ARG SWIFT_PLATFORM=debian12
+ARG SWIFT_VERSION=6.1
+ARG SWIFT_WEBROOT=https://download.swift.org/swift-6.1-branch
+ARG SWIFT_WEBROOT="$SWIFT_WEBROOT/$SWIFT_PLATFORM"
+ARG SWIFT_PREFIX=/opt/swift/${SWIFT_VERSION}
+
+ENV SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    SWIFT_VERSION=$SWIFT_VERSION \
+    SWIFT_WEBROOT=$SWIFT_WEBROOT \
+    SWIFT_PREFIX=$SWIFT_PREFIX
+
+COPY swift-ci/dependencies/requirements.txt /dependencies/
+RUN pip3 install -r /dependencies/requirements.txt --break-system-packages
+
+RUN set -e; \
+    ARCH_NAME="$(dpkg --print-architecture)"; \
+    url=; \
+    case "${ARCH_NAME##*-}" in \
+        'amd64') \
+            OS_ARCH_SUFFIX=''; \
+            ;; \
+        'arm64') \
+            OS_ARCH_SUFFIX='-aarch64'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture: '$ARCH_NAME'"; exit 1 ;; \
+    esac; \
+    # - Grab curl here so we cache better up above
+    export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    && export $(curl -s ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g') \
+    && export $(curl -s ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g') \
+    && export DOWNLOAD_DIR=$(echo $download | sed "s/-${SWIFT_PLATFORM}${OS_ARCH_SUFFIX}.tar.gz//g") \
+    && echo $DOWNLOAD_DIR > .swift_tag \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fsSL ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz \
+    ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz.sig \
+    && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && mkdir -p $SWIFT_PREFIX \
+    && tar -xzf latest_toolchain.tar.gz --directory $SWIFT_PREFIX --strip-components=1 \
+    && chmod -R o+r $SWIFT_PREFIX/usr/lib/swift \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
+
+ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+
+USER build-user
+
+WORKDIR /home/build-user
+
+# Print Installed Swift Version
+RUN swift --version

--- a/nightly-6.1/debian/12/buildx/Dockerfile
+++ b/nightly-6.1/debian/12/buildx/Dockerfile
@@ -1,0 +1,96 @@
+FROM debian:12 as Base
+
+RUN groupadd -g 998 build-user && \
+    useradd -m -r -u 998 -g build-user build-user
+
+ENV DEBIAN_FRONTEND="noninteractive"
+
+RUN apt-get -y update && apt-get -y install \
+  build-essential       \
+  clang                 \
+  cmake                 \
+  diffutils             \
+  git                   \
+  icu-devtools          \
+  libcurl4-openssl-dev  \
+  libedit-dev           \
+  libicu-dev            \
+  libncurses-dev        \
+  libpython3-dev        \
+  libsqlite3-dev        \
+  libxml2-dev           \
+  ninja-build           \
+  pkg-config            \
+  python3-distutils     \
+  python3-pip           \
+  python3-pkg-resources \
+  python3-psutil        \
+  rsync                 \
+  swig                  \
+  systemtap-sdt-dev     \
+  tzdata                \
+  uuid-dev              \
+  zip                   \
+  libstdc++-12-dev
+
+
+ARG SWIFT_SIGNING_KEY=E813C892820A6FA13755B268F167DF1ACF9CE069
+ARG SWIFT_PLATFORM=debian12
+ARG SWIFT_VERSION=6.1
+ARG SWIFT_WEBROOT=https://download.swift.org/swift-6.1-branch
+ARG SWIFT_WEBROOT="$SWIFT_WEBROOT/$SWIFT_PLATFORM"
+ARG SWIFT_PREFIX=/opt/swift/${SWIFT_VERSION}
+
+# This is a small trick to enable if/else for arm64 and amd64.
+# Because of https://bugs.swift.org/browse/SR-14872 we need adjust tar options.
+FROM base AS base-amd64
+ARG OS_ARCH_SUFFIX=
+
+FROM base AS base-arm64
+ARG OS_ARCH_SUFFIX=-aarch64
+
+FROM base-$TARGETARCH AS final
+
+ENV SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    SWIFT_VERSION=$SWIFT_VERSION \
+    SWIFT_WEBROOT=$SWIFT_WEBROOT \
+    SWIFT_PREFIX=$SWIFT_PREFIX
+
+RUN set -e; \
+    ARCH_NAME="$(dpkg --print-architecture)"; \
+    url=; \
+    case "${ARCH_NAME##*-}" in \
+        'amd64') \
+            OS_ARCH_SUFFIX=''; \
+            ;; \
+        'arm64') \
+            OS_ARCH_SUFFIX='-aarch64'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture: '$ARCH_NAME'"; exit 1 ;; \
+    esac; \
+    # - Grab curl here so we cache better up above
+    export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    && export $(curl -s ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g') \
+    && export $(curl -s ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g') \
+    && export DOWNLOAD_DIR=$(echo $download | sed "s/-${SWIFT_PLATFORM}${OS_ARCH_SUFFIX}.tar.gz//g") \
+    && echo $DOWNLOAD_DIR > .swift_tag \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fsSL ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz \
+    ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz.sig \
+    && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && mkdir -p $SWIFT_PREFIX \
+    && tar -xzf latest_toolchain.tar.gz --directory $SWIFT_PREFIX --strip-components=1 \
+    && chmod -R o+r $SWIFT_PREFIX/usr/lib/swift \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
+
+ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+
+USER build-user
+
+WORKDIR /home/build-user
+
+# Print Installed Swift Version
+RUN swift --version

--- a/nightly-6.1/fedora/39/Dockerfile
+++ b/nightly-6.1/fedora/39/Dockerfile
@@ -1,0 +1,89 @@
+FROM fedora:39
+LABEL maintainer="Swift Infrastructure <swift-infrastructure@forums.swift.org>"
+LABEL description="Docker Container for the Swift programming language"
+
+RUN groupadd -g 998 build-user && \
+    useradd -m -r -u 998 -g build-user build-user
+
+RUN yum install -y \
+  libcurl-devel       \
+  libedit-devel       \
+  libicu-devel        \
+  sqlite-devel        \
+  libuuid-devel       \
+  libxml2-devel       \
+  python3             \
+  python3-pip         \
+  python3-devel       \
+  python3-distro      \
+  python3-setuptools  \
+  python3-six         \
+  rsync               \
+  swig                \
+  clang               \
+  perl-podlators      \
+  which               \
+  git                 \
+  cmake               \
+  zip                 \
+  unzip               \
+  diffutils           \
+  libstdc++-devel     \
+  libstdc++-static
+
+
+ARG SWIFT_SIGNING_KEY=E813C892820A6FA13755B268F167DF1ACF9CE069
+ARG SWIFT_PLATFORM=fedora39
+ARG SWIFT_VERSION=6.1
+ARG SWIFT_BRANCH=swift-${SWIFT_VERSION}-release
+ARG SWIFT_TAG=swift-${SWIFT_VERSION}-RELEASE
+ARG SWIFT_WEBROOT=https://download.swift.org/swift-6.1-branch
+ARG SWIFT_WEBROOT="$SWIFT_WEBROOT/$SWIFT_PLATFORM"
+ARG SWIFT_PREFIX=/opt/swift/${SWIFT_VERSION}
+
+ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
+    SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    SWIFT_VERSION=$SWIFT_VERSION \
+    SWIFT_BRANCH=$SWIFT_BRANCH \
+    SWIFT_TAG=$SWIFT_TAG \
+    SWIFT_WEBROOT=$SWIFT_WEBROOT \
+    SWIFT_PREFIX=$SWIFT_PREFIX
+
+COPY swift-ci/dependencies/requirements.txt /dependencies/
+RUN pip3 install -r /dependencies/requirements.txt
+
+RUN set -e; \
+    ARCH_NAME="$(rpm --eval '%{_arch}')"; \
+    url=; \
+    case "${ARCH_NAME##*-}" in \
+        'x86_64') \
+            OS_ARCH_SUFFIX=''; \
+            ;; \
+        'aarch64') \
+            OS_ARCH_SUFFIX='-aarch64'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture: '$ARCH_NAME'"; exit 1 ;; \
+    esac; \
+    export $(curl -s ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g') \
+    && export $(curl -s ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g') \
+    && export DOWNLOAD_DIR=$(echo $download | sed "s/-${SWIFT_PLATFORM}${OS_ARCH_SUFFIX}.tar.gz//g") \
+    && echo $DOWNLOAD_DIR > .swift_tag \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fsSL ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz \
+    ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz.sig \
+    && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && mkdir -p $SWIFT_PREFIX \
+    && tar -xzf latest_toolchain.tar.gz --directory $SWIFT_PREFIX --strip-components=1 \
+    && chmod -R o+r $SWIFT_PREFIX/usr/lib/swift \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
+
+ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+
+USER build-user
+
+WORKDIR /home/build-user
+
+# Print Installed Swift Version
+RUN swift --version

--- a/nightly-6.1/fedora/39/buildx/Dockerfile
+++ b/nightly-6.1/fedora/39/buildx/Dockerfile
@@ -1,0 +1,96 @@
+FROM fedora:39 AS base
+LABEL maintainer="Swift Infrastructure <swift-infrastructure@forums.swift.org>"
+LABEL description="Docker Container for the Swift programming language"
+
+RUN groupadd -g 998 build-user && \
+    useradd -m -r -u 998 -g build-user build-user
+
+RUN yum install -y \
+  libcurl-devel       \
+  libedit-devel       \
+  libicu-devel        \
+  sqlite-devel        \
+  libuuid-devel       \
+  libxml2-devel       \
+  python3             \
+  python3-pip         \
+  python3-devel       \
+  python3-distro      \
+  python3-setuptools  \
+  python3-six         \
+  rsync               \
+  swig                \
+  clang               \
+  perl-podlators      \
+  which               \
+  git                 \
+  cmake               \
+  zip                 \
+  unzip               \
+  diffutils           \
+  libstdc++-devel     \
+  libstdc++-static
+
+
+ARG SWIFT_SIGNING_KEY=E813C892820A6FA13755B268F167DF1ACF9CE069
+ARG SWIFT_PLATFORM=fedora39
+ARG SWIFT_VERSION=6.1
+ARG SWIFT_BRANCH=swift-${SWIFT_VERSION}-release
+ARG SWIFT_TAG=swift-${SWIFT_VERSION}-RELEASE
+ARG SWIFT_WEBROOT=https://download.swift.org/swift-6.1-branch
+ARG SWIFT_WEBROOT="$SWIFT_WEBROOT/$SWIFT_PLATFORM"
+ARG SWIFT_PREFIX=/opt/swift/${SWIFT_VERSION}
+
+# This is a small trick to enable if/else for arm64 and amd64.
+# Because of https://bugs.swift.org/browse/SR-14872 we need adjust tar options.
+FROM base AS base-amd64
+ARG OS_ARCH_SUFFIX=
+
+FROM base AS base-arm64
+ARG OS_ARCH_SUFFIX=-aarch64
+
+FROM base-$TARGETARCH AS final
+
+ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
+    SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    SWIFT_VERSION=$SWIFT_VERSION \
+    SWIFT_BRANCH=$SWIFT_BRANCH \
+    SWIFT_TAG=$SWIFT_TAG \
+    SWIFT_WEBROOT=$SWIFT_WEBROOT \
+    SWIFT_PREFIX=$SWIFT_PREFIX
+
+RUN set -e; \
+    ARCH_NAME="$(rpm --eval '%{_arch}')"; \
+    url=; \
+    case "${ARCH_NAME##*-}" in \
+        'x86_64') \
+            OS_ARCH_SUFFIX=''; \
+            ;; \
+        'aarch64') \
+            OS_ARCH_SUFFIX='-aarch64'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture: '$ARCH_NAME'"; exit 1 ;; \
+    esac; \
+    export $(curl -s ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g') \
+    && export $(curl -s ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g') \
+    && export DOWNLOAD_DIR=$(echo $download | sed "s/-${SWIFT_PLATFORM}${OS_ARCH_SUFFIX}.tar.gz//g") \
+    && echo $DOWNLOAD_DIR > .swift_tag \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fsSL ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz \
+    ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz.sig \
+    && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && mkdir -p $SWIFT_PREFIX \
+    && tar -xzf latest_toolchain.tar.gz --directory $SWIFT_PREFIX --strip-components=1 \
+    && chmod -R o+r $SWIFT_PREFIX/usr/lib/swift \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
+
+ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+
+USER build-user
+
+WORKDIR /home/build-user
+
+# Print Installed Swift Version
+RUN swift --version

--- a/nightly-6.1/ubuntu/24.04/buildx/Dockerfile
+++ b/nightly-6.1/ubuntu/24.04/buildx/Dockerfile
@@ -1,0 +1,85 @@
+FROM ubuntu:24.04 AS base
+LABEL maintainer="Swift Infrastructure <swift-infrastructure@forums.swift.org>"
+LABEL description="Docker Container for the Swift programming language"
+
+RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
+    apt-get -q install -y \
+    binutils \
+    git \
+    gnupg2 \
+    libc6-dev \
+    libcurl4-openssl-dev \
+    libncurses5-dev       \
+    libedit2 \
+    libgcc-11-dev \
+    libpython3-dev \
+    libsqlite3-0 \
+    libstdc++-11-dev \
+    libxml2-dev \
+    libz3-dev \
+    pkg-config \
+    tzdata \
+    zip \
+    zlib1g-dev \
+    && rm -r /var/lib/apt/lists/*
+
+# Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little
+
+# gpg --keyid-format LONG -k F167DF1ACF9CE069
+# pub   rsa4096/F167DF1ACF9CE069 2021-11-08 [SC] [expires: 2025-11-09]
+#       E813C892820A6FA13755B268F167DF1ACF9CE069
+# uid                 [ unknown] Swift Automatic Signing Key #4 <swift-infrastructure@forums.swift.org>
+ARG SWIFT_SIGNING_KEY=E813C892820A6FA13755B268F167DF1ACF9CE069
+ARG SWIFT_PLATFORM=ubuntu
+ARG OS_MAJOR_VER=24
+ARG OS_MIN_VER=04
+ARG SWIFT_WEBROOT=https://download.swift.org/swift-6.1-branch
+
+# This is a small trick to enable if/else for arm64 and amd64.
+# Because of https://bugs.swift.org/browse/SR-14872 we need adjust tar options.
+FROM base AS base-amd64
+ARG OS_ARCH_SUFFIX=
+
+FROM base AS base-arm64
+ARG OS_ARCH_SUFFIX=-aarch64
+
+FROM base-$TARGETARCH AS final
+
+ARG OS_VER=$SWIFT_PLATFORM$OS_MAJOR_VER.$OS_MIN_VER$OS_ARCH_SUFFIX
+ARG PLATFORM_WEBROOT="$SWIFT_WEBROOT/$SWIFT_PLATFORM$OS_MAJOR_VER$OS_MIN_VER$OS_ARCH_SUFFIX"
+
+RUN echo "${PLATFORM_WEBROOT}/latest-build.yml"
+
+RUN set -e; \
+    # - Grab curl here so we cache better up above
+    export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    # - Latest Toolchain info
+    && export $(curl -s ${PLATFORM_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
+    && export $(curl -s ${PLATFORM_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \
+    && export DOWNLOAD_DIR=$(echo $download | sed "s/-${OS_VER}.tar.gz//g") \
+    && echo $DOWNLOAD_DIR > .swift_tag \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fsSL ${PLATFORM_WEBROOT}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz \
+        ${PLATFORM_WEBROOT}/${DOWNLOAD_DIR}/${download_signature} -o latest_toolchain.tar.gz.sig \
+    && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
+    && gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
+    && chmod -R o+r /usr/lib/swift \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && apt-get purge --auto-remove -y curl
+
+# Print Installed Swift Version
+RUN swift --version
+
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bash.bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd

--- a/nightly-main/debian/12/Dockerfile
+++ b/nightly-main/debian/12/Dockerfile
@@ -1,0 +1,89 @@
+FROM debian:12
+
+RUN groupadd -g 998 build-user && \
+    useradd -m -r -u 998 -g build-user build-user
+
+ENV DEBIAN_FRONTEND="noninteractive"
+
+RUN apt-get -y update && apt-get -y install \
+  build-essential       \
+  clang                 \
+  cmake                 \
+  diffutils             \
+  git                   \
+  icu-devtools          \
+  libcurl4-openssl-dev  \
+  libedit-dev           \
+  libicu-dev            \
+  libncurses-dev        \
+  libpython3-dev        \
+  libsqlite3-dev        \
+  libxml2-dev           \
+  ninja-build           \
+  pkg-config            \
+  python3-distutils     \
+  python3-pip           \
+  python3-pkg-resources \
+  python3-psutil        \
+  rsync                 \
+  swig                  \
+  systemtap-sdt-dev     \
+  tzdata                \
+  uuid-dev              \
+  zip                   \
+  libstdc++-12-dev
+
+
+ARG SWIFT_SIGNING_KEY=E813C892820A6FA13755B268F167DF1ACF9CE069
+ARG SWIFT_PLATFORM=debian12
+ARG SWIFT_VERSION=6.2
+ARG SWIFT_WEBROOT=https://download.swift.org/development
+ARG SWIFT_WEBROOT="$SWIFT_WEBROOT/$SWIFT_PLATFORM"
+ARG SWIFT_PREFIX=/opt/swift/${SWIFT_VERSION}
+
+ENV SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    SWIFT_VERSION=$SWIFT_VERSION \
+    SWIFT_WEBROOT=$SWIFT_WEBROOT \
+    SWIFT_PREFIX=$SWIFT_PREFIX
+
+COPY swift-ci/dependencies/requirements.txt /dependencies/
+RUN pip3 install -r /dependencies/requirements.txt --break-system-packages
+
+RUN set -e; \
+    ARCH_NAME="$(dpkg --print-architecture)"; \
+    url=; \
+    case "${ARCH_NAME##*-}" in \
+        'amd64') \
+            OS_ARCH_SUFFIX=''; \
+            ;; \
+        'arm64') \
+            OS_ARCH_SUFFIX='-aarch64'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture: '$ARCH_NAME'"; exit 1 ;; \
+    esac; \
+    # - Grab curl here so we cache better up above
+    export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    && export $(curl -s ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g') \
+    && export $(curl -s ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g') \
+    && export DOWNLOAD_DIR=$(echo $download | sed "s/-${SWIFT_PLATFORM}${OS_ARCH_SUFFIX}.tar.gz//g") \
+    && echo $DOWNLOAD_DIR > .swift_tag \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fsSL ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz \
+    ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz.sig \
+    && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && mkdir -p $SWIFT_PREFIX \
+    && tar -xzf latest_toolchain.tar.gz --directory $SWIFT_PREFIX --strip-components=1 \
+    && chmod -R o+r $SWIFT_PREFIX/usr/lib/swift \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
+
+ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+
+USER build-user
+
+WORKDIR /home/build-user
+
+# Print Installed Swift Version
+RUN swift --version

--- a/nightly-main/debian/12/buildx/Dockerfile
+++ b/nightly-main/debian/12/buildx/Dockerfile
@@ -1,0 +1,96 @@
+FROM debian:12 as Base
+
+RUN groupadd -g 998 build-user && \
+    useradd -m -r -u 998 -g build-user build-user
+
+ENV DEBIAN_FRONTEND="noninteractive"
+
+RUN apt-get -y update && apt-get -y install \
+  build-essential       \
+  clang                 \
+  cmake                 \
+  diffutils             \
+  git                   \
+  icu-devtools          \
+  libcurl4-openssl-dev  \
+  libedit-dev           \
+  libicu-dev            \
+  libncurses-dev        \
+  libpython3-dev        \
+  libsqlite3-dev        \
+  libxml2-dev           \
+  ninja-build           \
+  pkg-config            \
+  python3-distutils     \
+  python3-pip           \
+  python3-pkg-resources \
+  python3-psutil        \
+  rsync                 \
+  swig                  \
+  systemtap-sdt-dev     \
+  tzdata                \
+  uuid-dev              \
+  zip                   \
+  libstdc++-12-dev
+
+
+ARG SWIFT_SIGNING_KEY=E813C892820A6FA13755B268F167DF1ACF9CE069
+ARG SWIFT_PLATFORM=debian12
+ARG SWIFT_VERSION=6.2
+ARG SWIFT_WEBROOT=https://download.swift.org/development
+ARG SWIFT_WEBROOT="$SWIFT_WEBROOT/$SWIFT_PLATFORM"
+ARG SWIFT_PREFIX=/opt/swift/${SWIFT_VERSION}
+
+# This is a small trick to enable if/else for arm64 and amd64.
+# Because of https://bugs.swift.org/browse/SR-14872 we need adjust tar options.
+FROM base AS base-amd64
+ARG OS_ARCH_SUFFIX=
+
+FROM base AS base-arm64
+ARG OS_ARCH_SUFFIX=-aarch64
+
+FROM base-$TARGETARCH AS final
+
+ENV SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    SWIFT_VERSION=$SWIFT_VERSION \
+    SWIFT_WEBROOT=$SWIFT_WEBROOT \
+    SWIFT_PREFIX=$SWIFT_PREFIX
+
+RUN set -e; \
+    ARCH_NAME="$(dpkg --print-architecture)"; \
+    url=; \
+    case "${ARCH_NAME##*-}" in \
+        'amd64') \
+            OS_ARCH_SUFFIX=''; \
+            ;; \
+        'arm64') \
+            OS_ARCH_SUFFIX='-aarch64'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture: '$ARCH_NAME'"; exit 1 ;; \
+    esac; \
+    # - Grab curl here so we cache better up above
+    export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    && export $(curl -s ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g') \
+    && export $(curl -s ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g') \
+    && export DOWNLOAD_DIR=$(echo $download | sed "s/-${SWIFT_PLATFORM}${OS_ARCH_SUFFIX}.tar.gz//g") \
+    && echo $DOWNLOAD_DIR > .swift_tag \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fsSL ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz \
+    ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz.sig \
+    && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && mkdir -p $SWIFT_PREFIX \
+    && tar -xzf latest_toolchain.tar.gz --directory $SWIFT_PREFIX --strip-components=1 \
+    && chmod -R o+r $SWIFT_PREFIX/usr/lib/swift \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
+
+ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+
+USER build-user
+
+WORKDIR /home/build-user
+
+# Print Installed Swift Version
+RUN swift --version

--- a/nightly-main/fedora/39/Dockerfile
+++ b/nightly-main/fedora/39/Dockerfile
@@ -1,0 +1,89 @@
+FROM fedora:39
+LABEL maintainer="Swift Infrastructure <swift-infrastructure@forums.swift.org>"
+LABEL description="Docker Container for the Swift programming language"
+
+RUN groupadd -g 998 build-user && \
+    useradd -m -r -u 998 -g build-user build-user
+
+RUN yum install -y \
+  libcurl-devel       \
+  libedit-devel       \
+  libicu-devel        \
+  sqlite-devel        \
+  libuuid-devel       \
+  libxml2-devel       \
+  python3             \
+  python3-pip         \
+  python3-devel       \
+  python3-distro      \
+  python3-setuptools  \
+  python3-six         \
+  rsync               \
+  swig                \
+  clang               \
+  perl-podlators      \
+  which               \
+  git                 \
+  cmake               \
+  zip                 \
+  unzip               \
+  diffutils           \
+  libstdc++-devel     \
+  libstdc++-static
+
+
+ARG SWIFT_SIGNING_KEY=E813C892820A6FA13755B268F167DF1ACF9CE069
+ARG SWIFT_PLATFORM=fedora39
+ARG SWIFT_VERSION=6.2
+ARG SWIFT_BRANCH=swift-${SWIFT_VERSION}-release
+ARG SWIFT_TAG=swift-${SWIFT_VERSION}-RELEASE
+ARG SWIFT_WEBROOT=https://download.swift.org/development
+ARG SWIFT_WEBROOT="$SWIFT_WEBROOT/$SWIFT_PLATFORM"
+ARG SWIFT_PREFIX=/opt/swift/${SWIFT_VERSION}
+
+ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
+    SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    SWIFT_VERSION=$SWIFT_VERSION \
+    SWIFT_BRANCH=$SWIFT_BRANCH \
+    SWIFT_TAG=$SWIFT_TAG \
+    SWIFT_WEBROOT=$SWIFT_WEBROOT \
+    SWIFT_PREFIX=$SWIFT_PREFIX
+
+COPY swift-ci/dependencies/requirements.txt /dependencies/
+RUN pip3 install -r /dependencies/requirements.txt
+
+RUN set -e; \
+    ARCH_NAME="$(rpm --eval '%{_arch}')"; \
+    url=; \
+    case "${ARCH_NAME##*-}" in \
+        'x86_64') \
+            OS_ARCH_SUFFIX=''; \
+            ;; \
+        'aarch64') \
+            OS_ARCH_SUFFIX='-aarch64'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture: '$ARCH_NAME'"; exit 1 ;; \
+    esac; \
+    export $(curl -s ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g') \
+    && export $(curl -s ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g') \
+    && export DOWNLOAD_DIR=$(echo $download | sed "s/-${SWIFT_PLATFORM}${OS_ARCH_SUFFIX}.tar.gz//g") \
+    && echo $DOWNLOAD_DIR > .swift_tag \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fsSL ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz \
+    ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz.sig \
+    && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && mkdir -p $SWIFT_PREFIX \
+    && tar -xzf latest_toolchain.tar.gz --directory $SWIFT_PREFIX --strip-components=1 \
+    && chmod -R o+r $SWIFT_PREFIX/usr/lib/swift \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
+
+ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+
+USER build-user
+
+WORKDIR /home/build-user
+
+# Print Installed Swift Version
+RUN swift --version

--- a/nightly-main/fedora/39/buildx/Dockerfile
+++ b/nightly-main/fedora/39/buildx/Dockerfile
@@ -1,0 +1,96 @@
+FROM fedora:39 AS base
+LABEL maintainer="Swift Infrastructure <swift-infrastructure@forums.swift.org>"
+LABEL description="Docker Container for the Swift programming language"
+
+RUN groupadd -g 998 build-user && \
+    useradd -m -r -u 998 -g build-user build-user
+
+RUN yum install -y \
+  libcurl-devel       \
+  libedit-devel       \
+  libicu-devel        \
+  sqlite-devel        \
+  libuuid-devel       \
+  libxml2-devel       \
+  python3             \
+  python3-pip         \
+  python3-devel       \
+  python3-distro      \
+  python3-setuptools  \
+  python3-six         \
+  rsync               \
+  swig                \
+  clang               \
+  perl-podlators      \
+  which               \
+  git                 \
+  cmake               \
+  zip                 \
+  unzip               \
+  diffutils           \
+  libstdc++-devel     \
+  libstdc++-static
+
+
+ARG SWIFT_SIGNING_KEY=E813C892820A6FA13755B268F167DF1ACF9CE069
+ARG SWIFT_PLATFORM=fedora39
+ARG SWIFT_VERSION=6.2
+ARG SWIFT_BRANCH=swift-${SWIFT_VERSION}-release
+ARG SWIFT_TAG=swift-${SWIFT_VERSION}-RELEASE
+ARG SWIFT_WEBROOT=https://download.swift.org/development
+ARG SWIFT_WEBROOT="$SWIFT_WEBROOT/$SWIFT_PLATFORM"
+ARG SWIFT_PREFIX=/opt/swift/${SWIFT_VERSION}
+
+# This is a small trick to enable if/else for arm64 and amd64.
+# Because of https://bugs.swift.org/browse/SR-14872 we need adjust tar options.
+FROM base AS base-amd64
+ARG OS_ARCH_SUFFIX=
+
+FROM base AS base-arm64
+ARG OS_ARCH_SUFFIX=-aarch64
+
+FROM base-$TARGETARCH AS final
+
+ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
+    SWIFT_PLATFORM=$SWIFT_PLATFORM \
+    SWIFT_VERSION=$SWIFT_VERSION \
+    SWIFT_BRANCH=$SWIFT_BRANCH \
+    SWIFT_TAG=$SWIFT_TAG \
+    SWIFT_WEBROOT=$SWIFT_WEBROOT \
+    SWIFT_PREFIX=$SWIFT_PREFIX
+
+RUN set -e; \
+    ARCH_NAME="$(rpm --eval '%{_arch}')"; \
+    url=; \
+    case "${ARCH_NAME##*-}" in \
+        'x86_64') \
+            OS_ARCH_SUFFIX=''; \
+            ;; \
+        'aarch64') \
+            OS_ARCH_SUFFIX='-aarch64'; \
+            ;; \
+        *) echo >&2 "error: unsupported architecture: '$ARCH_NAME'"; exit 1 ;; \
+    esac; \
+    export $(curl -s ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g') \
+    && export $(curl -s ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g') \
+    && export DOWNLOAD_DIR=$(echo $download | sed "s/-${SWIFT_PLATFORM}${OS_ARCH_SUFFIX}.tar.gz//g") \
+    && echo $DOWNLOAD_DIR > .swift_tag \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fsSL ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz \
+    ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz.sig \
+    && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && mkdir -p $SWIFT_PREFIX \
+    && tar -xzf latest_toolchain.tar.gz --directory $SWIFT_PREFIX --strip-components=1 \
+    && chmod -R o+r $SWIFT_PREFIX/usr/lib/swift \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
+
+ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+
+USER build-user
+
+WORKDIR /home/build-user
+
+# Print Installed Swift Version
+RUN swift --version

--- a/nightly-main/ubuntu/24.04/buildx/Dockerfile
+++ b/nightly-main/ubuntu/24.04/buildx/Dockerfile
@@ -1,0 +1,85 @@
+FROM ubuntu:24.04 AS base
+LABEL maintainer="Swift Infrastructure <swift-infrastructure@forums.swift.org>"
+LABEL description="Docker Container for the Swift programming language"
+
+RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
+    apt-get -q install -y \
+    binutils \
+    git \
+    gnupg2 \
+    libc6-dev \
+    libcurl4-openssl-dev \
+    libncurses5-dev       \
+    libedit2 \
+    libgcc-11-dev \
+    libpython3-dev \
+    libsqlite3-0 \
+    libstdc++-11-dev \
+    libxml2-dev \
+    libz3-dev \
+    pkg-config \
+    tzdata \
+    zip \
+    zlib1g-dev \
+    && rm -r /var/lib/apt/lists/*
+
+# Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little
+
+# gpg --keyid-format LONG -k FAF6989E1BC16FEA
+# pub   rsa4096/FAF6989E1BC16FEA 2019-11-07 [SC] [expires: 2021-11-06]
+#       8A7495662C3CD4AE18D95637FAF6989E1BC16FEA
+# uid                 [ unknown] Swift Automatic Signing Key #3 <swift-infrastructure@swift.org>
+ARG SWIFT_SIGNING_KEY=8A7495662C3CD4AE18D95637FAF6989E1BC16FEA
+ARG SWIFT_PLATFORM=ubuntu
+ARG OS_MAJOR_VER=24
+ARG OS_MIN_VER=04
+ARG SWIFT_WEBROOT=https://download.swift.org/development
+
+# This is a small trick to enable if/else for arm64 and amd64.
+# Because of https://bugs.swift.org/browse/SR-14872 we need adjust tar options.
+FROM base AS base-amd64
+ARG OS_ARCH_SUFFIX=
+
+FROM base AS base-arm64
+ARG OS_ARCH_SUFFIX=-aarch64
+
+FROM base-$TARGETARCH AS final
+
+ARG OS_VER=$SWIFT_PLATFORM$OS_MAJOR_VER.$OS_MIN_VER$OS_ARCH_SUFFIX
+ARG PLATFORM_WEBROOT="$SWIFT_WEBROOT/$SWIFT_PLATFORM$OS_MAJOR_VER$OS_MIN_VER$OS_ARCH_SUFFIX"
+
+RUN echo "${PLATFORM_WEBROOT}/latest-build.yml"
+
+RUN set -e; \
+    # - Grab curl here so we cache better up above
+    export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
+    # - Latest Toolchain info
+    && export $(curl -s ${PLATFORM_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
+    && export $(curl -s ${PLATFORM_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \
+    && export DOWNLOAD_DIR=$(echo $download | sed "s/-${OS_VER}.tar.gz//g") \
+    && echo $DOWNLOAD_DIR > .swift_tag \
+    # - Download the GPG keys, Swift toolchain, and toolchain signature, and verify.
+    && export GNUPGHOME="$(mktemp -d)" \
+    && curl -fsSL ${PLATFORM_WEBROOT}/${DOWNLOAD_DIR}/${download} -o latest_toolchain.tar.gz \
+        ${PLATFORM_WEBROOT}/${DOWNLOAD_DIR}/${download_signature} -o latest_toolchain.tar.gz.sig \
+    && curl -fSsL https://swift.org/keys/all-keys.asc | gpg --import -  \
+    && gpg --batch --verify latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    # - Unpack the toolchain, set libs permissions, and clean up.
+    && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
+    && chmod -R o+r /usr/lib/swift \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && apt-get purge --auto-remove -y curl
+
+# Print Installed Swift Version
+RUN swift --version
+
+RUN echo "[ -n \"\${TERM:-}\" -a -r /etc/motd ] && cat /etc/motd" >> /etc/bash.bashrc; \
+    ( \
+      printf "################################################################\n"; \
+      printf "# %-60s #\n" ""; \
+      printf "# %-60s #\n" "Swift Nightly Docker Image"; \
+      printf "# %-60s #\n" "Tag: $(cat .swift_tag)"; \
+      printf "# %-60s #\n" ""; \
+      printf "################################################################\n" \
+    ) > /etc/motd


### PR DESCRIPTION
Add the following platforms to both main and release/6.1 for the nightly builds
* Debian 12
* Fedora 39
* Ubuntu 2404