### PR TITLE
Revert "Update Git version in some windows Docker images (#450)"

### DIFF
--- a/nightly-6.0/windows/1809/Dockerfile
+++ b/nightly-6.0/windows/1809/Dockerfile
@@ -15,8 +15,8 @@ RUN reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem" /t 
 
 # Install Git.
 # See: git-[version]-[bit].exe /SAVEINF=git.inf and /?
-ARG GIT=https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/Git-2.49.0-64-bit.exe
-ARG GIT_SHA256=726056328967F242FE6E9AFBFE7823903A928AFF577DCF6F517F2FB6DA6CE83C
+ARG GIT=https://github.com/git-for-windows/git/releases/download/v2.42.0.windows.2/Git-2.42.0.2-64-bit.exe
+ARG GIT_SHA256=BD9B41641A258FD16D99BEECEC66132160331D685DFB4C714CEA2BCC78D63BDB
 RUN Write-Host -NoNewLine ('Downloading {0} ... ' -f ${env:GIT});               \
     Invoke-WebRequest -Uri ${env:GIT} -OutFile git.exe;                         \
     Write-Host '✓';                                                             \

--- a/nightly-6.0/windows/LTSC2022/Dockerfile
+++ b/nightly-6.0/windows/LTSC2022/Dockerfile
@@ -15,8 +15,8 @@ RUN reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem" /t 
 
 # Install Git.
 # See: git-[version]-[bit].exe /SAVEINF=git.inf and /?
-ARG GIT=https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/Git-2.49.0-64-bit.exe
-ARG GIT_SHA256=726056328967F242FE6E9AFBFE7823903A928AFF577DCF6F517F2FB6DA6CE83C
+ARG GIT=https://github.com/git-for-windows/git/releases/download/v2.42.0.windows.2/Git-2.42.0.2-64-bit.exe
+ARG GIT_SHA256=BD9B41641A258FD16D99BEECEC66132160331D685DFB4C714CEA2BCC78D63BDB
 RUN Write-Host -NoNewLine ('Downloading {0} ... ' -f ${env:GIT});               \
     Invoke-WebRequest -Uri ${env:GIT} -OutFile git.exe;                         \
     Write-Host '✓';                                                             \

--- a/nightly-6.1/windows/1809/Dockerfile
+++ b/nightly-6.1/windows/1809/Dockerfile
@@ -15,8 +15,8 @@ RUN reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem" /t 
 
 # Install Git.
 # See: git-[version]-[bit].exe /SAVEINF=git.inf and /?
-ARG GIT=https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/Git-2.49.0-64-bit.exe
-ARG GIT_SHA256=726056328967F242FE6E9AFBFE7823903A928AFF577DCF6F517F2FB6DA6CE83C
+ARG GIT=https://github.com/git-for-windows/git/releases/download/v2.42.0.windows.2/Git-2.42.0.2-64-bit.exe
+ARG GIT_SHA256=BD9B41641A258FD16D99BEECEC66132160331D685DFB4C714CEA2BCC78D63BDB
 RUN Write-Host -NoNewLine ('Downloading {0} ... ' -f ${env:GIT});               \
     Invoke-WebRequest -Uri ${env:GIT} -OutFile git.exe;                         \
     Write-Host '✓';                                                             \

--- a/nightly-6.1/windows/LTSC2022/Dockerfile
+++ b/nightly-6.1/windows/LTSC2022/Dockerfile
@@ -15,8 +15,8 @@ RUN reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem" /t 
 
 # Install Git.
 # See: git-[version]-[bit].exe /SAVEINF=git.inf and /?
-ARG GIT=https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/Git-2.49.0-64-bit.exe
-ARG GIT_SHA256=726056328967F242FE6E9AFBFE7823903A928AFF577DCF6F517F2FB6DA6CE83C
+ARG GIT=https://github.com/git-for-windows/git/releases/download/v2.42.0.windows.2/Git-2.42.0.2-64-bit.exe
+ARG GIT_SHA256=BD9B41641A258FD16D99BEECEC66132160331D685DFB4C714CEA2BCC78D63BDB
 RUN Write-Host -NoNewLine ('Downloading {0} ... ' -f ${env:GIT});               \
     Invoke-WebRequest -Uri ${env:GIT} -OutFile git.exe;                         \
     Write-Host '✓';                                                             \

--- a/nightly-main/windows/1809/Dockerfile
+++ b/nightly-main/windows/1809/Dockerfile
@@ -15,8 +15,8 @@ RUN reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem" /t 
 
 # Install Git.
 # See: git-[version]-[bit].exe /SAVEINF=git.inf and /?
-ARG GIT=https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/Git-2.49.0-64-bit.exe
-ARG GIT_SHA256=726056328967F242FE6E9AFBFE7823903A928AFF577DCF6F517F2FB6DA6CE83C
+ARG GIT=https://github.com/git-for-windows/git/releases/download/v2.42.0.windows.2/Git-2.42.0.2-64-bit.exe
+ARG GIT_SHA256=BD9B41641A258FD16D99BEECEC66132160331D685DFB4C714CEA2BCC78D63BDB
 RUN Write-Host -NoNewLine ('Downloading {0} ... ' -f ${env:GIT});               \
     Invoke-WebRequest -Uri ${env:GIT} -OutFile git.exe;                         \
     Write-Host '✓';                                                             \

--- a/nightly-main/windows/LTSC2022/Dockerfile
+++ b/nightly-main/windows/LTSC2022/Dockerfile
@@ -15,8 +15,8 @@ RUN reg add "HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem" /t 
 
 # Install Git.
 # See: git-[version]-[bit].exe /SAVEINF=git.inf and /?
-ARG GIT=https://github.com/git-for-windows/git/releases/download/v2.49.0.windows.1/Git-2.49.0-64-bit.exe
-ARG GIT_SHA256=726056328967F242FE6E9AFBFE7823903A928AFF577DCF6F517F2FB6DA6CE83C
+ARG GIT=https://github.com/git-for-windows/git/releases/download/v2.42.0.windows.2/Git-2.42.0.2-64-bit.exe
+ARG GIT_SHA256=BD9B41641A258FD16D99BEECEC66132160331D685DFB4C714CEA2BCC78D63BDB
 RUN Write-Host -NoNewLine ('Downloading {0} ... ' -f ${env:GIT});               \
     Invoke-WebRequest -Uri ${env:GIT} -OutFile git.exe;                         \
     Write-Host '✓';                                                             \


### PR DESCRIPTION
This reverts commit 53ddeccfdc3944b84206a08c387cee33af544f89.

This appears to be causing SwiftPM or a child process to exit when building packages in these images.