### PR TITLE
Add missing `LD_LIBRARY_PATH` to Dockerfiles for Debian 12/13 and Fedora 39/41

### DIFF
--- a/nightly-6.1/debian/12/Dockerfile
+++ b/nightly-6.1/debian/12/Dockerfile
@@ -61,6 +61,7 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${SWIFT_PREFIX}/usr/lib/swift/linux"
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.1/debian/12/buildx/Dockerfile
+++ b/nightly-6.1/debian/12/buildx/Dockerfile
@@ -71,6 +71,7 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${SWIFT_PREFIX}/usr/lib/swift/linux"
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.1/fedora/39/Dockerfile
+++ b/nightly-6.1/fedora/39/Dockerfile
@@ -63,6 +63,7 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${SWIFT_PREFIX}/usr/lib/swift/linux"
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.1/fedora/39/buildx/Dockerfile
+++ b/nightly-6.1/fedora/39/buildx/Dockerfile
@@ -73,6 +73,7 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${SWIFT_PREFIX}/usr/lib/swift/linux"
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.2/debian/12/Dockerfile
+++ b/nightly-6.2/debian/12/Dockerfile
@@ -61,6 +61,7 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${SWIFT_PREFIX}/usr/lib/swift/linux"
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.2/debian/12/buildx/Dockerfile
+++ b/nightly-6.2/debian/12/buildx/Dockerfile
@@ -71,6 +71,7 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${SWIFT_PREFIX}/usr/lib/swift/linux"
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.2/fedora/39/Dockerfile
+++ b/nightly-6.2/fedora/39/Dockerfile
@@ -64,6 +64,7 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${SWIFT_PREFIX}/usr/lib/swift/linux"
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.2/fedora/39/buildx/Dockerfile
+++ b/nightly-6.2/fedora/39/buildx/Dockerfile
@@ -74,6 +74,7 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${SWIFT_PREFIX}/usr/lib/swift/linux"
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.3/debian/12/Dockerfile
+++ b/nightly-6.3/debian/12/Dockerfile
@@ -61,6 +61,7 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${SWIFT_PREFIX}/usr/lib/swift/linux"
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.3/debian/12/buildx/Dockerfile
+++ b/nightly-6.3/debian/12/buildx/Dockerfile
@@ -71,6 +71,7 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${SWIFT_PREFIX}/usr/lib/swift/linux"
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.3/fedora/39/Dockerfile
+++ b/nightly-6.3/fedora/39/Dockerfile
@@ -64,6 +64,7 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${SWIFT_PREFIX}/usr/lib/swift/linux"
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.3/fedora/39/buildx/Dockerfile
+++ b/nightly-6.3/fedora/39/buildx/Dockerfile
@@ -74,6 +74,7 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${SWIFT_PREFIX}/usr/lib/swift/linux"
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.3/fedora/41/Dockerfile
+++ b/nightly-6.3/fedora/41/Dockerfile
@@ -65,6 +65,7 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${SWIFT_PREFIX}/usr/lib/swift/linux"
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.3/fedora/41/buildx/Dockerfile
+++ b/nightly-6.3/fedora/41/buildx/Dockerfile
@@ -75,6 +75,7 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${SWIFT_PREFIX}/usr/lib/swift/linux"
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.4.x/debian/12/Dockerfile
+++ b/nightly-6.4.x/debian/12/Dockerfile
@@ -64,6 +64,7 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${SWIFT_PREFIX}/usr/lib/swift/linux"
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.4.x/debian/12/buildx/Dockerfile
+++ b/nightly-6.4.x/debian/12/buildx/Dockerfile
@@ -73,6 +73,7 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${SWIFT_PREFIX}/usr/lib/swift/linux"
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.4.x/debian/13/Dockerfile
+++ b/nightly-6.4.x/debian/13/Dockerfile
@@ -64,6 +64,7 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${SWIFT_PREFIX}/usr/lib/swift/linux"
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.4.x/debian/13/buildx/Dockerfile
+++ b/nightly-6.4.x/debian/13/buildx/Dockerfile
@@ -73,6 +73,7 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${SWIFT_PREFIX}/usr/lib/swift/linux"
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.4.x/fedora/39/Dockerfile
+++ b/nightly-6.4.x/fedora/39/Dockerfile
@@ -64,6 +64,7 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${SWIFT_PREFIX}/usr/lib/swift/linux"
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.4.x/fedora/39/buildx/Dockerfile
+++ b/nightly-6.4.x/fedora/39/buildx/Dockerfile
@@ -74,6 +74,7 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${SWIFT_PREFIX}/usr/lib/swift/linux"
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.4.x/fedora/41/Dockerfile
+++ b/nightly-6.4.x/fedora/41/Dockerfile
@@ -65,6 +65,7 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${SWIFT_PREFIX}/usr/lib/swift/linux"
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.4.x/fedora/41/buildx/Dockerfile
+++ b/nightly-6.4.x/fedora/41/buildx/Dockerfile
@@ -75,6 +75,7 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${SWIFT_PREFIX}/usr/lib/swift/linux"
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-main/debian/12/Dockerfile
+++ b/nightly-main/debian/12/Dockerfile
@@ -64,6 +64,7 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${SWIFT_PREFIX}/usr/lib/swift/linux"
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-main/debian/12/buildx/Dockerfile
+++ b/nightly-main/debian/12/buildx/Dockerfile
@@ -73,6 +73,7 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${SWIFT_PREFIX}/usr/lib/swift/linux"
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-main/debian/13/Dockerfile
+++ b/nightly-main/debian/13/Dockerfile
@@ -64,6 +64,7 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${SWIFT_PREFIX}/usr/lib/swift/linux"
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-main/debian/13/buildx/Dockerfile
+++ b/nightly-main/debian/13/buildx/Dockerfile
@@ -73,6 +73,7 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${SWIFT_PREFIX}/usr/lib/swift/linux"
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-main/fedora/39/Dockerfile
+++ b/nightly-main/fedora/39/Dockerfile
@@ -64,6 +64,7 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${SWIFT_PREFIX}/usr/lib/swift/linux"
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-main/fedora/39/buildx/Dockerfile
+++ b/nightly-main/fedora/39/buildx/Dockerfile
@@ -74,6 +74,7 @@ RUN set -e; \
     && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 ENV PATH="${SWIFT_PREFIX}/usr/bin:${PATH}"
+ENV LD_LIBRARY_PATH="${SWIFT_PREFIX}/usr/lib/swift/linux"
 
 # Print Installed Swift Version
 RUN swift --version


### PR DESCRIPTION
This PR fixes the following issue that you can not run executables built outside the container.

```console
$ cd
$ mkdir test
$ cd test
$ swift package init --type executable
...
$ swift build -c release
...
$ docker container run -it --rm -v $HOME/test:/test swiftlang/swift:nightly-main-debian12
...
build-user@087dcbadce38:~$ /test/.build/release/test
/test/.build/release/test: error while loading shared libraries: libswiftCore.so: cannot open shared object file: No such file or directory
```

The reason why `LD_LIBRARY_PATH` is needed is Dockerfiles for Debian 12 and Fedora39 install libraries under `${SWIFT_PREFIX}/usr/lib` instead of `/usr/lib`.