### PR TITLE
Change binutils-gold package dependency on Debian 12 to binutils

### DIFF
--- a/6.1/debian/12/Dockerfile
+++ b/6.1/debian/12/Dockerfile
@@ -5,7 +5,7 @@ LABEL description="Docker Container for the Swift programming language"
 
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
     apt-get -q install -y \
-    binutils-gold \
+    binutils \
     libicu-dev \
     libcurl4-openssl-dev \
     libedit-dev \


### PR DESCRIPTION
The binutils-gold package is a virtual package that is replaced by binutils in Debian bookworm.

Change the package dependency for the 6.1 Debian 12 docker images from binutils-gold to
binutils.