### PR TITLE
Update installed packages after nightly platform expansion

### DIFF
--- a/nightly-6.1/debian/12/Dockerfile
+++ b/nightly-6.1/debian/12/Dockerfile
@@ -3,35 +3,25 @@ FROM debian:12
 RUN groupadd -g 998 build-user && \
     useradd -m -r -u 998 -g build-user build-user
 
-ENV DEBIAN_FRONTEND="noninteractive"
-
-RUN apt-get -y update && apt-get -y install \
-  build-essential       \
-  clang                 \
-  cmake                 \
-  diffutils             \
-  git                   \
-  icu-devtools          \
-  libcurl4-openssl-dev  \
-  libedit-dev           \
-  libicu-dev            \
-  libncurses-dev        \
-  libpython3-dev        \
-  libsqlite3-dev        \
-  libxml2-dev           \
-  ninja-build           \
-  pkg-config            \
-  python3-distutils     \
-  python3-pip           \
-  python3-pkg-resources \
-  python3-psutil        \
-  rsync                 \
-  swig                  \
-  systemtap-sdt-dev     \
-  tzdata                \
-  uuid-dev              \
-  zip                   \
-  libstdc++-12-dev
+RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
+    apt-get -q install -y \
+    binutils-gold \
+    curl \
+    gpg \
+    libicu-dev \
+    libcurl4-openssl-dev \
+    libedit-dev \
+    libsqlite3-dev \
+    libncurses-dev \
+    libpython3-dev \
+    libxml2-dev \
+    pkg-config \
+    uuid-dev \
+    tzdata \
+    git \
+    gcc \
+    libstdc++-12-dev \
+    && rm -r /var/lib/apt/lists/*
 
 
 ARG SWIFT_SIGNING_KEY=E813C892820A6FA13755B268F167DF1ACF9CE069
@@ -46,9 +36,6 @@ ENV SWIFT_PLATFORM=$SWIFT_PLATFORM \
     SWIFT_WEBROOT=$SWIFT_WEBROOT \
     SWIFT_PREFIX=$SWIFT_PREFIX
 
-COPY swift-ci/dependencies/requirements.txt /dependencies/
-RUN pip3 install -r /dependencies/requirements.txt --break-system-packages
-
 RUN set -e; \
     ARCH_NAME="$(dpkg --print-architecture)"; \
     url=; \
@@ -61,10 +48,7 @@ RUN set -e; \
             ;; \
         *) echo >&2 "error: unsupported architecture: '$ARCH_NAME'"; exit 1 ;; \
     esac; \
-    # - Grab curl here so we cache better up above
-    export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
-    && export $(curl -s ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g') \
+    export $(curl -s ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g') \
     && export $(curl -s ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g') \
     && export DOWNLOAD_DIR=$(echo $download | sed "s/-${SWIFT_PLATFORM}${OS_ARCH_SUFFIX}.tar.gz//g") \
     && echo $DOWNLOAD_DIR > .swift_tag \

--- a/nightly-6.1/debian/12/buildx/Dockerfile
+++ b/nightly-6.1/debian/12/buildx/Dockerfile
@@ -3,35 +3,25 @@ FROM debian:12 as Base
 RUN groupadd -g 998 build-user && \
     useradd -m -r -u 998 -g build-user build-user
 
-ENV DEBIAN_FRONTEND="noninteractive"
-
-RUN apt-get -y update && apt-get -y install \
-  build-essential       \
-  clang                 \
-  cmake                 \
-  diffutils             \
-  git                   \
-  icu-devtools          \
-  libcurl4-openssl-dev  \
-  libedit-dev           \
-  libicu-dev            \
-  libncurses-dev        \
-  libpython3-dev        \
-  libsqlite3-dev        \
-  libxml2-dev           \
-  ninja-build           \
-  pkg-config            \
-  python3-distutils     \
-  python3-pip           \
-  python3-pkg-resources \
-  python3-psutil        \
-  rsync                 \
-  swig                  \
-  systemtap-sdt-dev     \
-  tzdata                \
-  uuid-dev              \
-  zip                   \
-  libstdc++-12-dev
+RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
+    apt-get -q install -y \
+    binutils-gold \
+    curl \
+    gpg \
+    libicu-dev \
+    libcurl4-openssl-dev \
+    libedit-dev \
+    libsqlite3-dev \
+    libncurses-dev \
+    libpython3-dev \
+    libxml2-dev \
+    pkg-config \
+    uuid-dev \
+    tzdata \
+    git \
+    gcc \
+    libstdc++-12-dev \
+    && rm -r /var/lib/apt/lists/*
 
 
 ARG SWIFT_SIGNING_KEY=E813C892820A6FA13755B268F167DF1ACF9CE069
@@ -68,10 +58,7 @@ RUN set -e; \
             ;; \
         *) echo >&2 "error: unsupported architecture: '$ARCH_NAME'"; exit 1 ;; \
     esac; \
-    # - Grab curl here so we cache better up above
-    export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
-    && export $(curl -s ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g') \
+    export $(curl -s ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g') \
     && export $(curl -s ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g') \
     && export DOWNLOAD_DIR=$(echo $download | sed "s/-${SWIFT_PLATFORM}${OS_ARCH_SUFFIX}.tar.gz//g") \
     && echo $DOWNLOAD_DIR > .swift_tag \

--- a/nightly-6.1/fedora/39/Dockerfile
+++ b/nightly-6.1/fedora/39/Dockerfile
@@ -5,30 +5,19 @@ LABEL description="Docker Container for the Swift programming language"
 RUN groupadd -g 998 build-user && \
     useradd -m -r -u 998 -g build-user build-user
 
-RUN yum install -y \
-  libcurl-devel       \
-  libedit-devel       \
-  libicu-devel        \
-  sqlite-devel        \
-  libuuid-devel       \
-  libxml2-devel       \
-  python3             \
-  python3-pip         \
-  python3-devel       \
-  python3-distro      \
-  python3-setuptools  \
-  python3-six         \
-  rsync               \
-  swig                \
-  clang               \
-  perl-podlators      \
-  which               \
-  git                 \
-  cmake               \
-  zip                 \
-  unzip               \
-  diffutils           \
-  libstdc++-devel     \
+RUN yum -y install \
+  binutils \
+  gcc \
+  git \
+  unzip \
+  libcurl-devel \
+  libedit-devel \
+  libicu-devel \
+  sqlite-devel \
+  libuuid-devel \
+  libxml2-devel \
+  python3-devel \
+  libstdc++-devel \
   libstdc++-static
 
 
@@ -48,9 +37,6 @@ ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
     SWIFT_TAG=$SWIFT_TAG \
     SWIFT_WEBROOT=$SWIFT_WEBROOT \
     SWIFT_PREFIX=$SWIFT_PREFIX
-
-COPY swift-ci/dependencies/requirements.txt /dependencies/
-RUN pip3 install -r /dependencies/requirements.txt
 
 RUN set -e; \
     ARCH_NAME="$(rpm --eval '%{_arch}')"; \

--- a/nightly-6.1/fedora/39/buildx/Dockerfile
+++ b/nightly-6.1/fedora/39/buildx/Dockerfile
@@ -5,30 +5,19 @@ LABEL description="Docker Container for the Swift programming language"
 RUN groupadd -g 998 build-user && \
     useradd -m -r -u 998 -g build-user build-user
 
-RUN yum install -y \
-  libcurl-devel       \
-  libedit-devel       \
-  libicu-devel        \
-  sqlite-devel        \
-  libuuid-devel       \
-  libxml2-devel       \
-  python3             \
-  python3-pip         \
-  python3-devel       \
-  python3-distro      \
-  python3-setuptools  \
-  python3-six         \
-  rsync               \
-  swig                \
-  clang               \
-  perl-podlators      \
-  which               \
-  git                 \
-  cmake               \
-  zip                 \
-  unzip               \
-  diffutils           \
-  libstdc++-devel     \
+RUN yum -y install \
+  binutils \
+  gcc \
+  git \
+  unzip \
+  libcurl-devel \
+  libedit-devel \
+  libicu-devel \
+  sqlite-devel \
+  libuuid-devel \
+  libxml2-devel \
+  python3-devel \
+  libstdc++-devel \
   libstdc++-static
 
 

--- a/nightly-6.1/ubuntu/24.04/Dockerfile
+++ b/nightly-6.1/ubuntu/24.04/Dockerfile
@@ -6,17 +6,16 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     apt-get -q install -y \
     binutils \
     git \
-    unzip \
     gnupg2 \
     libc6-dev \
     libcurl4-openssl-dev \
+    libncurses5-dev       \
     libedit2 \
     libgcc-13-dev \
     libpython3-dev \
     libsqlite3-0 \
     libstdc++-13-dev \
     libxml2-dev \
-    libncurses-dev \
     libz3-dev \
     pkg-config \
     tzdata \

--- a/nightly-6.1/ubuntu/24.04/Dockerfile
+++ b/nightly-6.1/ubuntu/24.04/Dockerfile
@@ -5,6 +5,7 @@ LABEL description="Docker Container for the Swift programming language"
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
     apt-get -q install -y \
     binutils \
+    curl \
     git \
     gnupg2 \
     libc6-dev \
@@ -44,11 +45,7 @@ ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
 RUN echo "${SWIFT_WEBROOT}/latest-build.yml"
 
 RUN set -e; \
-    # - Grab curl here so we cache better up above
-    export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
-    # - Latest Toolchain info
-    && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
+    export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \
     && export DOWNLOAD_DIR=$(echo $download | sed "s/-${OS_VER}.tar.gz//g") \
     && echo $DOWNLOAD_DIR > .swift_tag \

--- a/nightly-6.1/ubuntu/24.04/buildx/Dockerfile
+++ b/nightly-6.1/ubuntu/24.04/buildx/Dockerfile
@@ -5,6 +5,7 @@ LABEL description="Docker Container for the Swift programming language"
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
     apt-get -q install -y \
     binutils \
+    curl \
     git \
     gnupg2 \
     libc6-dev \
@@ -50,11 +51,7 @@ ARG PLATFORM_WEBROOT="$SWIFT_WEBROOT/$SWIFT_PLATFORM$OS_MAJOR_VER$OS_MIN_VER$OS_
 RUN echo "${PLATFORM_WEBROOT}/latest-build.yml"
 
 RUN set -e; \
-    # - Grab curl here so we cache better up above
-    export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
-    # - Latest Toolchain info
-    && export $(curl -s ${PLATFORM_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
+    export $(curl -s ${PLATFORM_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
     && export $(curl -s ${PLATFORM_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \
     && export DOWNLOAD_DIR=$(echo $download | sed "s/-${OS_VER}.tar.gz//g") \
     && echo $DOWNLOAD_DIR > .swift_tag \

--- a/nightly-6.1/ubuntu/24.04/buildx/Dockerfile
+++ b/nightly-6.1/ubuntu/24.04/buildx/Dockerfile
@@ -11,15 +11,14 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     libcurl4-openssl-dev \
     libncurses5-dev       \
     libedit2 \
-    libgcc-11-dev \
+    libgcc-13-dev \
     libpython3-dev \
     libsqlite3-0 \
-    libstdc++-11-dev \
+    libstdc++-13-dev \
     libxml2-dev \
     libz3-dev \
     pkg-config \
     tzdata \
-    zip \
     zlib1g-dev \
     && rm -r /var/lib/apt/lists/*
 

--- a/nightly-main/debian/12/Dockerfile
+++ b/nightly-main/debian/12/Dockerfile
@@ -3,35 +3,25 @@ FROM debian:12
 RUN groupadd -g 998 build-user && \
     useradd -m -r -u 998 -g build-user build-user
 
-ENV DEBIAN_FRONTEND="noninteractive"
-
-RUN apt-get -y update && apt-get -y install \
-  build-essential       \
-  clang                 \
-  cmake                 \
-  diffutils             \
-  git                   \
-  icu-devtools          \
-  libcurl4-openssl-dev  \
-  libedit-dev           \
-  libicu-dev            \
-  libncurses-dev        \
-  libpython3-dev        \
-  libsqlite3-dev        \
-  libxml2-dev           \
-  ninja-build           \
-  pkg-config            \
-  python3-distutils     \
-  python3-pip           \
-  python3-pkg-resources \
-  python3-psutil        \
-  rsync                 \
-  swig                  \
-  systemtap-sdt-dev     \
-  tzdata                \
-  uuid-dev              \
-  zip                   \
-  libstdc++-12-dev
+RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
+    apt-get -q install -y \
+    binutils-gold \
+    curl \
+    gpg \
+    libicu-dev \
+    libcurl4-openssl-dev \
+    libedit-dev \
+    libsqlite3-dev \
+    libncurses-dev \
+    libpython3-dev \
+    libxml2-dev \
+    pkg-config \
+    uuid-dev \
+    tzdata \
+    git \
+    gcc \
+    libstdc++-12-dev \
+    && rm -r /var/lib/apt/lists/*
 
 
 ARG SWIFT_SIGNING_KEY=E813C892820A6FA13755B268F167DF1ACF9CE069
@@ -61,10 +51,7 @@ RUN set -e; \
             ;; \
         *) echo >&2 "error: unsupported architecture: '$ARCH_NAME'"; exit 1 ;; \
     esac; \
-    # - Grab curl here so we cache better up above
-    export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
-    && export $(curl -s ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g') \
+    export $(curl -s ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g') \
     && export $(curl -s ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g') \
     && export DOWNLOAD_DIR=$(echo $download | sed "s/-${SWIFT_PLATFORM}${OS_ARCH_SUFFIX}.tar.gz//g") \
     && echo $DOWNLOAD_DIR > .swift_tag \

--- a/nightly-main/debian/12/buildx/Dockerfile
+++ b/nightly-main/debian/12/buildx/Dockerfile
@@ -5,33 +5,25 @@ RUN groupadd -g 998 build-user && \
 
 ENV DEBIAN_FRONTEND="noninteractive"
 
-RUN apt-get -y update && apt-get -y install \
-  build-essential       \
-  clang                 \
-  cmake                 \
-  diffutils             \
-  git                   \
-  icu-devtools          \
-  libcurl4-openssl-dev  \
-  libedit-dev           \
-  libicu-dev            \
-  libncurses-dev        \
-  libpython3-dev        \
-  libsqlite3-dev        \
-  libxml2-dev           \
-  ninja-build           \
-  pkg-config            \
-  python3-distutils     \
-  python3-pip           \
-  python3-pkg-resources \
-  python3-psutil        \
-  rsync                 \
-  swig                  \
-  systemtap-sdt-dev     \
-  tzdata                \
-  uuid-dev              \
-  zip                   \
-  libstdc++-12-dev
+RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
+    apt-get -q install -y \
+    binutils-gold \
+    curl \
+    gpg \
+    libicu-dev \
+    libcurl4-openssl-dev \
+    libedit-dev \
+    libsqlite3-dev \
+    libncurses-dev \
+    libpython3-dev \
+    libxml2-dev \
+    pkg-config \
+    uuid-dev \
+    tzdata \
+    git \
+    gcc \
+    libstdc++-12-dev \
+    && rm -r /var/lib/apt/lists/*
 
 
 ARG SWIFT_SIGNING_KEY=E813C892820A6FA13755B268F167DF1ACF9CE069
@@ -68,10 +60,7 @@ RUN set -e; \
             ;; \
         *) echo >&2 "error: unsupported architecture: '$ARCH_NAME'"; exit 1 ;; \
     esac; \
-    # - Grab curl here so we cache better up above
-    export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
-    && export $(curl -s ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g') \
+    export $(curl -s ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g') \
     && export $(curl -s ${SWIFT_WEBROOT}${OS_ARCH_SUFFIX}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g') \
     && export DOWNLOAD_DIR=$(echo $download | sed "s/-${SWIFT_PLATFORM}${OS_ARCH_SUFFIX}.tar.gz//g") \
     && echo $DOWNLOAD_DIR > .swift_tag \

--- a/nightly-main/fedora/39/Dockerfile
+++ b/nightly-main/fedora/39/Dockerfile
@@ -5,30 +5,19 @@ LABEL description="Docker Container for the Swift programming language"
 RUN groupadd -g 998 build-user && \
     useradd -m -r -u 998 -g build-user build-user
 
-RUN yum install -y \
-  libcurl-devel       \
-  libedit-devel       \
-  libicu-devel        \
-  sqlite-devel        \
-  libuuid-devel       \
-  libxml2-devel       \
-  python3             \
-  python3-pip         \
-  python3-devel       \
-  python3-distro      \
-  python3-setuptools  \
-  python3-six         \
-  rsync               \
-  swig                \
-  clang               \
-  perl-podlators      \
-  which               \
-  git                 \
-  cmake               \
-  zip                 \
-  unzip               \
-  diffutils           \
-  libstdc++-devel     \
+RUN yum -y install \
+  binutils \
+  gcc \
+  git \
+  unzip \
+  libcurl-devel \
+  libedit-devel \
+  libicu-devel \
+  sqlite-devel \
+  libuuid-devel \
+  libxml2-devel \
+  python3-devel \
+  libstdc++-devel \
   libstdc++-static
 
 
@@ -48,9 +37,6 @@ ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
     SWIFT_TAG=$SWIFT_TAG \
     SWIFT_WEBROOT=$SWIFT_WEBROOT \
     SWIFT_PREFIX=$SWIFT_PREFIX
-
-COPY swift-ci/dependencies/requirements.txt /dependencies/
-RUN pip3 install -r /dependencies/requirements.txt
 
 RUN set -e; \
     ARCH_NAME="$(rpm --eval '%{_arch}')"; \

--- a/nightly-main/fedora/39/buildx/Dockerfile
+++ b/nightly-main/fedora/39/buildx/Dockerfile
@@ -5,30 +5,19 @@ LABEL description="Docker Container for the Swift programming language"
 RUN groupadd -g 998 build-user && \
     useradd -m -r -u 998 -g build-user build-user
 
-RUN yum install -y \
-  libcurl-devel       \
-  libedit-devel       \
-  libicu-devel        \
-  sqlite-devel        \
-  libuuid-devel       \
-  libxml2-devel       \
-  python3             \
-  python3-pip         \
-  python3-devel       \
-  python3-distro      \
-  python3-setuptools  \
-  python3-six         \
-  rsync               \
-  swig                \
-  clang               \
-  perl-podlators      \
-  which               \
-  git                 \
-  cmake               \
-  zip                 \
-  unzip               \
-  diffutils           \
-  libstdc++-devel     \
+RUN yum -y install \
+  binutils \
+  gcc \
+  git \
+  unzip \
+  libcurl-devel \
+  libedit-devel \
+  libicu-devel \
+  sqlite-devel \
+  libuuid-devel \
+  libxml2-devel \
+  python3-devel \
+  libstdc++-devel \
   libstdc++-static
 
 

--- a/nightly-main/ubuntu/24.04/Dockerfile
+++ b/nightly-main/ubuntu/24.04/Dockerfile
@@ -5,6 +5,7 @@ LABEL description="Docker Container for the Swift programming language"
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
     apt-get -q install -y \
     binutils \
+    curl \
     git \
     gnupg2 \
     libc6-dev \

--- a/nightly-main/ubuntu/24.04/Dockerfile
+++ b/nightly-main/ubuntu/24.04/Dockerfile
@@ -6,17 +6,16 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     apt-get -q install -y \
     binutils \
     git \
-    unzip \
     gnupg2 \
     libc6-dev \
     libcurl4-openssl-dev \
+    libncurses5-dev       \
     libedit2 \
     libgcc-13-dev \
     libpython3-dev \
     libsqlite3-0 \
     libstdc++-13-dev \
     libxml2-dev \
-    libncurses-dev \
     libz3-dev \
     pkg-config \
     tzdata \
@@ -46,11 +45,7 @@ ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \
 RUN echo "${SWIFT_WEBROOT}/latest-build.yml"
 
 RUN set -e; \
-    # - Grab curl here so we cache better up above
-    export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
-    # - Latest Toolchain info
-    && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
+    export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
     && export $(curl -s ${SWIFT_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \
     && export DOWNLOAD_DIR=$(echo $download | sed "s/-${OS_VER}.tar.gz//g") \
     && echo $DOWNLOAD_DIR > .swift_tag \

--- a/nightly-main/ubuntu/24.04/buildx/Dockerfile
+++ b/nightly-main/ubuntu/24.04/buildx/Dockerfile
@@ -5,6 +5,7 @@ LABEL description="Docker Container for the Swift programming language"
 RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && apt-get -q update && \
     apt-get -q install -y \
     binutils \
+    curl \
     git \
     gnupg2 \
     libc6-dev \

--- a/nightly-main/ubuntu/24.04/buildx/Dockerfile
+++ b/nightly-main/ubuntu/24.04/buildx/Dockerfile
@@ -11,18 +11,16 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
     libcurl4-openssl-dev \
     libncurses5-dev       \
     libedit2 \
-    libgcc-11-dev \
+    libgcc-13-dev \
     libpython3-dev \
     libsqlite3-0 \
-    libstdc++-11-dev \
+    libstdc++-13-dev \
     libxml2-dev \
     libz3-dev \
     pkg-config \
     tzdata \
-    zip \
     zlib1g-dev \
     && rm -r /var/lib/apt/lists/*
-
 # Everything up to here should cache nicely between Swift versions, assuming dev dependencies change little
 
 # gpg --keyid-format LONG -k FAF6989E1BC16FEA
@@ -51,11 +49,7 @@ ARG PLATFORM_WEBROOT="$SWIFT_WEBROOT/$SWIFT_PLATFORM$OS_MAJOR_VER$OS_MIN_VER$OS_
 RUN echo "${PLATFORM_WEBROOT}/latest-build.yml"
 
 RUN set -e; \
-    # - Grab curl here so we cache better up above
-    export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -q update && apt-get -q install -y curl && rm -rf /var/lib/apt/lists/* \
-    # - Latest Toolchain info
-    && export $(curl -s ${PLATFORM_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
+    export $(curl -s ${PLATFORM_WEBROOT}/latest-build.yml | grep 'download:' | sed 's/:[^:\/\/]/=/g')  \
     && export $(curl -s ${PLATFORM_WEBROOT}/latest-build.yml | grep 'download_signature:' | sed 's/:[^:\/\/]/=/g')  \
     && export DOWNLOAD_DIR=$(echo $download | sed "s/-${OS_VER}.tar.gz//g") \
     && echo $DOWNLOAD_DIR > .swift_tag \


### PR DESCRIPTION
As part of https://github.com/swiftlang/swift-docker/pull/449,

The following nightly platforms were added to 6.1 and main:
* fedora31
* ubuntu2404
* debian12

I mistakenly copied the package lists from [swiftci/main](https://github.com/swiftlang/swift-docker/tree/main/swift-ci/main) folder resulting in more installed packages than necessary. This PR rectifies that by slimming down the package lists and doing small refactors accordingly. The package lists now are taken from the [6.1](https://github.com/swiftlang/swift-docker/tree/main/6.1) folder as a reference