### PR TITLE
Add `--compressed` flag to static linux sdk signature downloads.

### DIFF
--- a/swift-ci/sdks/static-linux/scripts/install-swift.sh
+++ b/swift-ci/sdks/static-linux/scripts/install-swift.sh
@@ -47,7 +47,7 @@ curl -fsSL "${SWIFT_WEBROOT}/${download_dir}/${download_signature}" -o toolchain
 
 echo "Fetching keys"
 
-curl -fsSL https://swift.org/keys/all-keys.asc | gpg --import -
+curl -fsSL --compressed https://swift.org/keys/all-keys.asc | gpg --import -
 
 echo "Verifying signature"
 


### PR DESCRIPTION
Addresses https://ci.swift.org/job/oss-swift-6.2-package-static-sdk/35/.