### PR TITLE
Revert "Pin Windows images to the 6/9 nightly main snapshot"

### DIFF
--- a/nightly-main/windows/1809/Dockerfile
+++ b/nightly-main/windows/1809/Dockerfile
@@ -128,10 +128,8 @@ RUN Write-Host -NoNewLine ('Downloading {0} ... ' -f ${env:VSB});               
 
 # Install Swift toolchain.
 ARG SWIFT_RELEASE_METADATA=https://download.swift.org/development/windows10/latest-build.json
-# Pinned to 6/9 snapshot due to https://github.com/swiftlang/swift/issues/82281
-# $SWIFT_URL = "\"https://download.swift.org/development/windows10/$($Release.dir)/$($Release.download)\""; \
 RUN $Release = curl.exe -sL ${env:SWIFT_RELEASE_METADATA} | ConvertFrom-JSON;   \
-    $SWIFT_URL = "\"https://download.swift.org/development/windows10/swift-DEVELOPMENT-SNAPSHOT-2025-06-09-a/swift-DEVELOPMENT-SNAPSHOT-2025-06-09-a-windows10.exe\""; \
+    $SWIFT_URL = "\"https://download.swift.org/development/windows10/$($Release.dir)/$($Release.download)\""; \
     Write-Host -NoNewLine ('Downloading {0} ... ' -f ${SWIFT_URL});             \
     Invoke-WebRequest -Uri ${SWIFT_URL} -OutFile installer.exe;                 \
     Write-Host '✓';                                                             \

--- a/nightly-main/windows/LTSC2022/Dockerfile
+++ b/nightly-main/windows/LTSC2022/Dockerfile
@@ -128,10 +128,8 @@ RUN Write-Host -NoNewLine ('Downloading {0} ... ' -f ${env:VSB});               
 
 # Install Swift toolchain.
 ARG SWIFT_RELEASE_METADATA=https://download.swift.org/development/windows10/latest-build.json
-# Pinned to 6/9 snapshot due to https://github.com/swiftlang/swift/issues/82281
-# $SWIFT_URL = "\"https://download.swift.org/development/windows10/$($Release.dir)/$($Release.download)\""; \
 RUN $Release = curl.exe -sL ${env:SWIFT_RELEASE_METADATA} | ConvertFrom-JSON;   \
-    $SWIFT_URL = "\"https://download.swift.org/development/windows10/swift-DEVELOPMENT-SNAPSHOT-2025-06-09-a/swift-DEVELOPMENT-SNAPSHOT-2025-06-09-a-windows10.exe\""; \
+    $SWIFT_URL = "\"https://download.swift.org/development/windows10/$($Release.dir)/$($Release.download)\""; \
     Write-Host -NoNewLine ('Downloading {0} ... ' -f ${SWIFT_URL});             \
     Invoke-WebRequest -Uri ${SWIFT_URL} -OutFile installer.exe;                 \
     Write-Host '✓';                                                             \


### PR DESCRIPTION
Reverts swiftlang/swift-docker#478

We've effectively worked around the issue that led to this pinning elsewhere, so I think it's best to unpin at this point.