### PR TITLE
Install python modules in AL2023 bootstrap

### DIFF
--- a/swift-ci/main/amazon-linux/2023/Bootstrap/Dockerfile
+++ b/swift-ci/main/amazon-linux/2023/Bootstrap/Dockerfile
@@ -24,6 +24,7 @@ RUN yum -y install \
   python3-devel \
   python3-distro \
   python3-setuptools \
+  python3-pip \
   rsync \
   sqlite-devel \
   swig \
@@ -37,8 +38,8 @@ RUN yum -y install \
 RUN curl -fsSL "https://github.com/Kitware/CMake/releases/download/v4.0.2/cmake-4.0.2-linux-`uname -m`.tar.gz" \
   | tar --strip-components=1 -xz -C /usr/local
 
-
-# TODO: Still need to install bits for lldb
+COPY swift-ci/dependencies/requirements.txt /dependencies/
+RUN pip3 install -r /dependencies/requirements.txt
 
 USER build-user
 WORKDIR /home/build-user


### PR DESCRIPTION
swift-bootstrap-amazonlinux-2023-x86_64 has a failing lldb test caused by the absence of the 'pexpect' python module. This pr is meant to resolve that error and was tested with an at desk build.