### PR TITLE
Update Node version to 22.17.0

### DIFF
--- a/swift-ci/swift-docc-render/Dockerfile
+++ b/swift-ci/swift-docc-render/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.17.4
+FROM node:22.17.0
 
 ARG SWIFT_DOCC_RENDER_BRANCH=main
 


### PR DESCRIPTION
We need to update the Node version to 22.17.0 in the Swift CI for Docc-Render, to ensure compatibility with the updated Node version [used in the project](https://github.com/swiftlang/swift-docc-render/pull/952).

It fixes: rdar://156708326