### PR TITLE
[CI] Prune docker buildx build cache after each image

### DIFF
--- a/ci_test.py
+++ b/ci_test.py
@@ -96,6 +96,9 @@ def main():
                 '-t', image_name,
                 docker_dir
             ]
+            clean_command = f"docker buildx prune -af"
+        else:
+            clean_command = f"docker image rm {image_name}"
 
         status = run_command(cmd, log_file=log_file)
         results[dockerfile] = status
@@ -111,7 +114,7 @@ def main():
         run_command(cmd)
         print("[{}] - {}".format(results[dockerfile], dockerfile))
         sys.stdout.flush()
-        run_command(f"docker image rm {image_name}")
+        run_command(clean_command)
     run_command("docker image prune -f")
 
     for dockerfile in dockerfiles:


### PR DESCRIPTION
This will fix our CI running out of space.

When building with buildx, the docker images are not stored in the local docker registry since some of the platforms can not be stored in the local docker image registry. Instead, we should remove the buildx build cache after each build which is where the images are stored.

We will no longer see
```
Error response from daemon: No such image: nightly_6.2_fedora_39_dockerfile:latest
```
In our action logs, and the system should no longer run out of space on CI runs building builds images