### PR TITLE
Fix broken Amazon Linux 2 Dockerfiles

### DIFF
--- a/nightly-5.10/amazonlinux/2/Dockerfile
+++ b/nightly-5.10/amazonlinux/2/Dockerfile
@@ -57,7 +57,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-5.10/amazonlinux/2/buildx/Dockerfile
+++ b/nightly-5.10/amazonlinux/2/buildx/Dockerfile
@@ -64,7 +64,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-5.5/amazonlinux/2/Dockerfile
+++ b/nightly-5.5/amazonlinux/2/Dockerfile
@@ -54,7 +54,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-5.6/amazonlinux/2/Dockerfile
+++ b/nightly-5.6/amazonlinux/2/Dockerfile
@@ -54,7 +54,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-5.6/amazonlinux/2/buildx/Dockerfile
+++ b/nightly-5.6/amazonlinux/2/buildx/Dockerfile
@@ -63,7 +63,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / ${ADDITIONAL_TAR_OPTIONS} \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-5.7/amazonlinux/2/Dockerfile
+++ b/nightly-5.7/amazonlinux/2/Dockerfile
@@ -55,7 +55,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-5.7/amazonlinux/2/buildx/Dockerfile
+++ b/nightly-5.7/amazonlinux/2/buildx/Dockerfile
@@ -62,7 +62,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-5.8/amazonlinux/2/Dockerfile
+++ b/nightly-5.8/amazonlinux/2/Dockerfile
@@ -56,7 +56,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-5.8/amazonlinux/2/buildx/Dockerfile
+++ b/nightly-5.8/amazonlinux/2/buildx/Dockerfile
@@ -63,7 +63,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-5.9/amazonlinux/2/Dockerfile
+++ b/nightly-5.9/amazonlinux/2/Dockerfile
@@ -57,7 +57,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-5.9/amazonlinux/2/buildx/Dockerfile
+++ b/nightly-5.9/amazonlinux/2/buildx/Dockerfile
@@ -64,7 +64,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.0/amazonlinux/2/Dockerfile
+++ b/nightly-6.0/amazonlinux/2/Dockerfile
@@ -58,7 +58,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.0/amazonlinux/2/buildx/Dockerfile
+++ b/nightly-6.0/amazonlinux/2/buildx/Dockerfile
@@ -64,7 +64,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.1/amazonlinux/2/Dockerfile
+++ b/nightly-6.1/amazonlinux/2/Dockerfile
@@ -58,7 +58,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.1/amazonlinux/2/buildx/Dockerfile
+++ b/nightly-6.1/amazonlinux/2/buildx/Dockerfile
@@ -64,7 +64,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.2/amazonlinux/2/Dockerfile
+++ b/nightly-6.2/amazonlinux/2/Dockerfile
@@ -58,7 +58,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.2/amazonlinux/2/buildx/Dockerfile
+++ b/nightly-6.2/amazonlinux/2/buildx/Dockerfile
@@ -64,7 +64,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.3/amazonlinux/2/Dockerfile
+++ b/nightly-6.3/amazonlinux/2/Dockerfile
@@ -58,7 +58,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.3/amazonlinux/2/buildx/Dockerfile
+++ b/nightly-6.3/amazonlinux/2/buildx/Dockerfile
@@ -64,7 +64,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.4.x/amazonlinux/2/Dockerfile
+++ b/nightly-6.4.x/amazonlinux/2/Dockerfile
@@ -57,7 +57,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-6.4.x/amazonlinux/2/buildx/Dockerfile
+++ b/nightly-6.4.x/amazonlinux/2/buildx/Dockerfile
@@ -64,7 +64,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-main/amazonlinux/2/Dockerfile
+++ b/nightly-main/amazonlinux/2/Dockerfile
@@ -57,7 +57,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version

--- a/nightly-main/amazonlinux/2/buildx/Dockerfile
+++ b/nightly-main/amazonlinux/2/buildx/Dockerfile
@@ -64,7 +64,7 @@ RUN set -e; \
     # - Unpack the toolchain, set libs permissions, and clean up.
     && tar -xzf latest_toolchain.tar.gz --directory / --strip-components=1 \
     && chmod -R o+r /usr/lib/swift \
-    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz \
+    && rm -rf "$GNUPGHOME" latest_toolchain.tar.gz.sig latest_toolchain.tar.gz
 
 # Print Installed Swift Version
 RUN swift --version


### PR DESCRIPTION
All nightly Amazon Linux Dockerfiles have unintended dangling backslashes. This causes skipping succeeding `RUN swift --version`.

<https://nickjanetakis.com/blog/beware-of-dangling-backslashes-in-run-commands-in-your-dockerfile>