### PR TITLE
Android: push trunk back to API 24, stop rebuilding corelibs for the linux host, and update trunk CI to NDK 28c in preparation for the upcoming LTS NDK 30 release

### DIFF
--- a/swift-ci/sdks/android/build-docker
+++ b/swift-ci/sdks/android/build-docker
@@ -33,6 +33,11 @@ fi
 mkdir -p ${WORKDIR}
 WORKDIR=$(realpath ${WORKDIR})
 
+# Push trunk back to build against Android API 24
+if [[ -n "${SWIFT_VERSION}" && ($SWIFT_VERSION == scheme:main || $SWIFT_VERSION == tag:swift-DEV*) ]]; then
+    ANDROID_API=24
+fi
+
 HOST_OS=ubuntu24.04
 source ./scripts/toolchain-vars.sh
 

--- a/swift-ci/sdks/android/build-docker
+++ b/swift-ci/sdks/android/build-docker
@@ -33,11 +33,6 @@ fi
 mkdir -p ${WORKDIR}
 WORKDIR=$(realpath ${WORKDIR})
 
-# Push trunk back to build against Android API 24
-if [[ -n "${SWIFT_VERSION}" && ($SWIFT_VERSION == scheme:main || $SWIFT_VERSION == tag:swift-DEV*) ]]; then
-    ANDROID_API=24
-fi
-
 HOST_OS=ubuntu24.04
 source ./scripts/toolchain-vars.sh
 
@@ -53,6 +48,18 @@ perl -pi -g -we "s#(call rm ... \".\{LIBDISPATCH_BUILD_DIR\}\"\n(\s+)fi\n)#\1\2i
 
 # disable backtrace() for Android (needs either API33+ or libandroid-execinfo, or to manually add in backtrace backport)
 perl -pi -e 's;os\(Android\);os\(AndroidDISABLED\);g' ${WORKDIR}/source/swift-project/swift-testing/Sources/Testing/SourceAttribution/Backtrace.swift
+
+# Push trunk back to build against Android API 24 with NDK 28c
+if [[ -n "${SWIFT_VERSION}" && ($SWIFT_VERSION == scheme:main || $SWIFT_VERSION == tag:swift-DEV*) ]]; then
+    ANDROID_NDK_VERSION=android-ndk-r28c
+    ANDROID_API=24
+
+    rm ${WORKDIR}/source/swift-project/swift/test/Interop/Cxx/class/invalid-members/stdlib-containers-of-incomplete.swift
+    rm ${WORKDIR}/source/swift-project/swift/test/Interop/SwiftToCxx/stdlib/stdlib-in-cxx-no-diagnostics-generated-header.cpp
+    rm ${WORKDIR}/source/swift-project/swift/test/Reflection/typeref_decoding_packs.swift
+    rm ${WORKDIR}/source/swift-project/swift/test/Reflection/typeref_lowering.swift
+    rm ${WORKDIR}/source/swift-project/swift/test/Reflection/typeref_lowering_packs.swift
+fi
 
 mkdir -p ${WORKDIR}/products
 chmod ugo+rwx ${WORKDIR}/products

--- a/swift-ci/sdks/android/build-local
+++ b/swift-ci/sdks/android/build-local
@@ -33,6 +33,11 @@ fi
 mkdir -p ${WORKDIR}
 WORKDIR=$(realpath ${WORKDIR})
 
+# Push trunk back to build against Android API 24
+if [[ -n "${SWIFT_VERSION}" && ($SWIFT_VERSION == scheme:main || $SWIFT_VERSION == tag:swift-DEV*) ]]; then
+    ANDROID_API=24
+fi
+
 HOST_OS=ubuntu$(lsb_release -sr)
 source ./scripts/toolchain-vars.sh
 

--- a/swift-ci/sdks/android/build-local
+++ b/swift-ci/sdks/android/build-local
@@ -33,8 +33,9 @@ fi
 mkdir -p ${WORKDIR}
 WORKDIR=$(realpath ${WORKDIR})
 
-# Push trunk back to build against Android API 24
+# Push trunk back to build against Android API 24 with NDK 28c
 if [[ -n "${SWIFT_VERSION}" && ($SWIFT_VERSION == scheme:main || $SWIFT_VERSION == tag:swift-DEV*) ]]; then
+    ANDROID_NDK_VERSION=android-ndk-r28c
     ANDROID_API=24
 fi
 
@@ -75,6 +76,15 @@ perl -pi -g -we "s#(call rm ... \".\{LIBDISPATCH_BUILD_DIR\}\"\n(\s+)fi\n)#\1\2i
 
 # disable backtrace() for Android (needs either API33+ or libandroid-execinfo, or to manually add in backtrace backport)
 perl -pi -e 's;os\(Android\);os\(AndroidDISABLED\);g' ${WORKDIR}/source/swift-project/swift-testing/Sources/Testing/SourceAttribution/Backtrace.swift
+
+# Disable failing trunk tests when building against NDK 28c
+if [[ -n "${SWIFT_VERSION}" && ($SWIFT_VERSION == scheme:main || $SWIFT_VERSION == tag:swift-DEV*) ]]; then
+    rm ${WORKDIR}/source/swift-project/swift/test/Interop/Cxx/class/invalid-members/stdlib-containers-of-incomplete.swift
+    rm ${WORKDIR}/source/swift-project/swift/test/Interop/SwiftToCxx/stdlib/stdlib-in-cxx-no-diagnostics-generated-header.cpp
+    rm ${WORKDIR}/source/swift-project/swift/test/Reflection/typeref_decoding_packs.swift
+    rm ${WORKDIR}/source/swift-project/swift/test/Reflection/typeref_lowering.swift
+    rm ${WORKDIR}/source/swift-project/swift/test/Reflection/typeref_lowering_packs.swift
+fi
 
 mkdir -p ${WORKDIR}/products
 

--- a/swift-ci/sdks/android/scripts/build.sh
+++ b/swift-ci/sdks/android/scripts/build.sh
@@ -351,6 +351,7 @@ for arch in $archs; do
             -DLIBXML2_WITH_ICU=NO \
             -DLIBXML2_WITH_ICONV=NO \
             -DLIBXML2_WITH_LZMA=NO \
+            -DLIBXML2_WITH_TESTS=OFF \
             -DBUILD_SHARED_LIBS=OFF \
             -DBUILD_STATIC_LIBS=ON
 

--- a/swift-ci/sdks/android/scripts/build.sh
+++ b/swift-ci/sdks/android/scripts/build.sh
@@ -487,6 +487,7 @@ for arch in $archs; do
             --host-test \
             --skip-test-linux \
             --skip-test-xctest --skip-test-foundation \
+            --skip-clean-libdispatch --skip-clean-foundation --skip-clean-xctest \
             --build-swift-static-stdlib \
             --swift-install-components='compiler;clang-resource-dir-symlink;license;stdlib;sdk-overlay' \
             --install-swift \

--- a/swift-ci/sdks/android/scripts/build.sh
+++ b/swift-ci/sdks/android/scripts/build.sh
@@ -502,10 +502,12 @@ for arch in $archs; do
             --cross-compile-append-host-target-to-destdir=False 
             # --extra-cmake-options='-DCMAKE_EXTRA_LINK_FLAGS="-Wl,-z,max-page-size=16384"'
         # need to remove the arch-specific portion of the Swift resource dir in
-        # the build directory, through this symlink that we create in the NDK to
+        # the build directories, through this symlink that we create in the NDK to
         # the build directory, or else we get errors like:
-        # error: could not find module '_Builtin_float' for target 'x86_64-unknown-linux-android'; found: aarch64-unknown-linux-android, at: /home/runner/work/_temp/swift-android-sdk/ndk/android-ndk-r27c/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/swift/android/_Builtin_float.swiftmodule
+        # error: could not find module '_Builtin_float' for target 'x86_64-unknown-linux-android'; found: aarch64-unknown-linux-android, at: /home/runner/work/_temp/swift-android-sdk/ndk/android-ndk-r28c/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/swift/android/_Builtin_float.swiftmodule
         rm -rf $ndk_installation/sysroot/usr/lib/swift/android
+        rm -rf $ndk_installation/sysroot/usr/lib/swift/../swift_static/android
+        rm -rf $ndk_installation/sysroot/usr/lib/swift/../../../swift-linux-x86_64/lib/swift{,_static}/android
     quiet_popd
     groupend
 done


### PR DESCRIPTION
[The Android workgroup agreed on pushing the CI and SDK back to be built against API 24](https://forums.swift.org/t/swift-android-workgroup-meeting-notes-january-28th-2026/84429), so this pull does so for trunk alone, as we're still waiting on a pull for 6.3, swiftlang/swift-corelibs-foundation#5398.

I also added some flags to avoid rebuilding some corelibs for the linux host, as we currently invoke `build_script` once for each Android arch, and that script deletes and rebuilds the previously built corelibs by default each time, so this makes sure we don't do that.

The real solution is to add a build flag to avoid building the corelibs for the host altogether when building cross-compilation toolchains like this, so I'm working on a handful of pulls for that and to slim down the number of repos checked out for these SDK builds, but this pull will do in the meantime.

What does the CI team think about adding some github CI for these Android pulls, so we can check them before merging? I'm working on an external github CI, swift-android-sdk/swift-docker#19, that will run much more often than this official CI and alert me to problems much more quickly, but that wouldn't be as useful for new contributors that would have to find that repo first.

Also, it would be good if we could add some compiler caching to this official Android CI and set it up so it runs on every compiler pull _before_ merging, though this new Android CI job would not be required to pass yet for those pulls to be merged.