### PR TITLE
Fix nightly Debian 12/13 Dockerfiles

### DIFF
--- a/nightly-6.4.x/debian/12/Dockerfile
+++ b/nightly-6.4.x/debian/12/Dockerfile
@@ -33,9 +33,6 @@ ENV SWIFT_PLATFORM=$SWIFT_PLATFORM \
     SWIFT_WEBROOT=$SWIFT_WEBROOT \
     SWIFT_PREFIX=$SWIFT_PREFIX
 
-COPY swift-ci/dependencies/requirements.txt /dependencies/
-RUN pip3 install -r /dependencies/requirements.txt --break-system-packages
-
 RUN set -e; \
     ARCH_NAME="$(dpkg --print-architecture)"; \
     url=; \

--- a/nightly-6.4.x/debian/13/Dockerfile
+++ b/nightly-6.4.x/debian/13/Dockerfile
@@ -33,9 +33,6 @@ ENV SWIFT_PLATFORM=$SWIFT_PLATFORM \
     SWIFT_WEBROOT=$SWIFT_WEBROOT \
     SWIFT_PREFIX=$SWIFT_PREFIX
 
-COPY swift-ci/dependencies/requirements.txt /dependencies/
-RUN pip3 install -r /dependencies/requirements.txt --break-system-packages
-
 RUN set -e; \
     ARCH_NAME="$(dpkg --print-architecture)"; \
     url=; \

--- a/nightly-main/debian/12/Dockerfile
+++ b/nightly-main/debian/12/Dockerfile
@@ -33,9 +33,6 @@ ENV SWIFT_PLATFORM=$SWIFT_PLATFORM \
     SWIFT_WEBROOT=$SWIFT_WEBROOT \
     SWIFT_PREFIX=$SWIFT_PREFIX
 
-COPY swift-ci/dependencies/requirements.txt /dependencies/
-RUN pip3 install -r /dependencies/requirements.txt --break-system-packages
-
 RUN set -e; \
     ARCH_NAME="$(dpkg --print-architecture)"; \
     url=; \

--- a/nightly-main/debian/13/Dockerfile
+++ b/nightly-main/debian/13/Dockerfile
@@ -33,9 +33,6 @@ ENV SWIFT_PLATFORM=$SWIFT_PLATFORM \
     SWIFT_WEBROOT=$SWIFT_WEBROOT \
     SWIFT_PREFIX=$SWIFT_PREFIX
 
-COPY swift-ci/dependencies/requirements.txt /dependencies/
-RUN pip3 install -r /dependencies/requirements.txt --break-system-packages
-
 RUN set -e; \
     ARCH_NAME="$(dpkg --print-architecture)"; \
     url=; \


### PR DESCRIPTION
These Dockerfiles contain invalid instructions copied from swift-ci Dockerfiles, so building the images will always fail.

This PR removes them.