### PR TITLE
Don't build the embedded stdlib or copy the trunk SwiftBridging header on Android CI

### DIFF
--- a/swift-ci/sdks/android/scripts/build.sh
+++ b/swift-ci/sdks/android/scripts/build.sh
@@ -496,6 +496,7 @@ for arch in $archs; do
             --xctest --install-xctest \
             --swift-testing --install-swift-testing \
             --swift-testing-macros --install-swift-testing-macros \
+            --build-embedded-stdlib=False \
             --cross-compile-build-swift-tools=False \
             --libdispatch-cmake-options=-DCMAKE_SHARED_LINKER_FLAGS= \
             --foundation-cmake-options=-DCMAKE_SHARED_LINKER_FLAGS= \

--- a/swift-ci/sdks/android/scripts/build.sh
+++ b/swift-ci/sdks/android/scripts/build.sh
@@ -654,7 +654,10 @@ for arch in $archs; do
     quiet_pushd ${sdk_staging}/${arch}/usr
         rm -rf bin lib/clang local
         rm -r include/*
-        cp -r ${swift_source_dir}/swift/lib/ClangImporter/SwiftBridging/{module.modulemap,swift} include/
+        # No longer needed in trunk snapshots and PRs
+        if [[ $swift_version != DEVELOPMENT-SNAPSHOT-* && $swift_version != PR ]]; then
+            cp -r ${swift_source_dir}/swift/lib/ClangImporter/SwiftBridging/{module.modulemap,swift} include/
+        fi
 
         arch_triple="$arch-linux-android"
         if [[ $arch == 'armv7' ]]; then


### PR DESCRIPTION
The Android CI is [broken right now only because we're building the embedded stdlib unnecessarily](https://ci.swift.org/job/oss-swift-package-swift-sdk-for-android/503/console), and that is currently broken on most linux toolchain CI, swiftlang/swift#89753. Disable it as [we just throw out the results](https://github.com/swiftlang/swift-docker/blob/05c46ef7c5867f040460def72f1497b76af32d71/swift-ci/sdks/android/scripts/build.sh#L664) anyway.

Let me test this locally and it should be ready to go.