### PR TITLE
[windows][lldb] fix quotes stripping

### DIFF
--- a/swift-ci/main/windows/lldb/1809/Dockerfile
+++ b/swift-ci/main/windows/lldb/1809/Dockerfile
@@ -36,7 +36,7 @@ RUN Invoke-WebRequest -Uri https://www.python.org/ftp/python/3.13.0/python-3.13.
     Start-Process -FilePath .\\python.exe -Wait -ArgumentList \
       '/quiet InstallAllUsers=1 PrependPath=1 Include_test=0'; \
     Remove-Item -Force python.exe
-RUN & "C:\Program Files\Python313\python.exe" -m pip install packaging==25.0 psutil==7.1.1 cryptography==47.0.0
+RUN python -m pip install packaging==25.0 psutil==7.1.1 cryptography==47.0.0
 
 # CMake 3.31.8
 RUN Invoke-WebRequest -Uri https://github.com/Kitware/CMake/releases/download/v3.31.8/cmake-3.31.8-windows-x86_64.msi -OutFile cmake.msi; \


### PR DESCRIPTION
Docker strips the quotes from `"C:\Program Files\Python313\python.exe"` which causes Powershell to only parse `C:\Program`. This causes the build to fail.

Replace the hardcoded path with `python` which is added to the PATH above. The Python installation is the only one on the PATH, there will be no ambiguities.