### PR TITLE
[windows][lldb] install GNU make

### DIFF
--- a/swift-ci/main/windows/lldb/1809/Dockerfile
+++ b/swift-ci/main/windows/lldb/1809/Dockerfile
@@ -60,8 +60,11 @@ RUN curl.exe -L -o swig.zip https://downloads.sourceforge.net/project/swig/swigw
 RUN git config --global core.symlink true; \
     git config --global core.autocrlf false
 
-# GNU make (from Git for Windows)
-RUN [Environment]::SetEnvironmentVariable('PATH', $env:PATH + ';C:\\Program Files\\Git\\usr\\bin', [EnvironmentVariableTarget]::Machine)
+# GNU make 4.4.1 (ezwinports)
+RUN Invoke-WebRequest -Uri https://downloads.sourceforge.net/project/ezwinports/make-4.4.1-without-guile-w32-bin.zip -OutFile make.zip; \
+    Expand-Archive -Path make.zip -DestinationPath C:\\GnuWin32Make-4.4.1; \
+    Remove-Item -Force make.zip; \
+    [Environment]::SetEnvironmentVariable('PATH', $env:PATH + ';C:\\GnuWin32Make-4.4.1\\bin', [EnvironmentVariableTarget]::Machine)
 
 # vcpkg + libxml2
 RUN git clone --depth 1 https://github.com/microsoft/vcpkg C:\\vcpkg; \


### PR DESCRIPTION
The version of Git we use to build the container does not ship with `make` which causes the lldb tests to fail (the test targets can't be built).

This patch installs `make` the same way it's done in `swift/utils/build.ps1`: https://github.com/swiftlang/swift/blob/dfb930340876408dc9bf963923763334a5e7f580/utils/build.ps1#L1665-L1672.