### PR TITLE
[6.3] Update Dockerfiles to Swift 6.3.3

### DIFF
--- a/6.3/amazonlinux/2/Dockerfile
+++ b/6.3/amazonlinux/2/Dockerfile
@@ -29,8 +29,8 @@ RUN yum -y install \
 # uid           [ unknown] Swift 6.x Release Signing Key <swift-infrastructure@forums.swift.org>
 ARG SWIFT_SIGNING_KEY=52BB7E3DE28A71BE22EC05FFEF80A866B47A981F
 ARG SWIFT_PLATFORM=amazonlinux2
-ARG SWIFT_BRANCH=swift-6.3.2-release
-ARG SWIFT_VERSION=swift-6.3.2-RELEASE
+ARG SWIFT_BRANCH=swift-6.3.3-release
+ARG SWIFT_VERSION=swift-6.3.3-RELEASE
 ARG SWIFT_WEBROOT=https://download.swift.org
 
 ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \

--- a/6.3/amazonlinux/2/slim/Dockerfile
+++ b/6.3/amazonlinux/2/slim/Dockerfile
@@ -9,8 +9,8 @@ LABEL description="Docker Container for the Swift programming language"
 # uid           [ unknown] Swift 6.x Release Signing Key <swift-infrastructure@forums.swift.org>
 ARG SWIFT_SIGNING_KEY=52BB7E3DE28A71BE22EC05FFEF80A866B47A981F
 ARG SWIFT_PLATFORM=amazonlinux2
-ARG SWIFT_BRANCH=swift-6.3.2-release
-ARG SWIFT_VERSION=swift-6.3.2-RELEASE
+ARG SWIFT_BRANCH=swift-6.3.3-release
+ARG SWIFT_VERSION=swift-6.3.3-RELEASE
 ARG SWIFT_WEBROOT=https://download.swift.org
 
 ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \

--- a/6.3/amazonlinux/2023/Dockerfile
+++ b/6.3/amazonlinux/2023/Dockerfile
@@ -30,8 +30,8 @@ RUN dnf -y swap gnupg2-minimal gnupg2-full
 # uid           [ unknown] Swift 6.x Release Signing Key <swift-infrastructure@forums.swift.org>
 ARG SWIFT_SIGNING_KEY=52BB7E3DE28A71BE22EC05FFEF80A866B47A981F
 ARG SWIFT_PLATFORM=amazonlinux2023
-ARG SWIFT_BRANCH=swift-6.3.2-release
-ARG SWIFT_VERSION=swift-6.3.2-RELEASE
+ARG SWIFT_BRANCH=swift-6.3.3-release
+ARG SWIFT_VERSION=swift-6.3.3-RELEASE
 ARG SWIFT_WEBROOT=https://download.swift.org
 
 ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \

--- a/6.3/amazonlinux/2023/slim/Dockerfile
+++ b/6.3/amazonlinux/2023/slim/Dockerfile
@@ -9,8 +9,8 @@ LABEL description="Docker Container for the Swift programming language"
 # uid           [ unknown] Swift 6.x Release Signing Key <swift-infrastructure@forums.swift.org>
 ARG SWIFT_SIGNING_KEY=52BB7E3DE28A71BE22EC05FFEF80A866B47A981F
 ARG SWIFT_PLATFORM=amazonlinux2023
-ARG SWIFT_BRANCH=swift-6.3.2-release
-ARG SWIFT_VERSION=swift-6.3.2-RELEASE
+ARG SWIFT_BRANCH=swift-6.3.3-release
+ARG SWIFT_VERSION=swift-6.3.3-RELEASE
 ARG SWIFT_WEBROOT=https://download.swift.org
 
 ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \

--- a/6.3/debian/12/Dockerfile
+++ b/6.3/debian/12/Dockerfile
@@ -28,8 +28,8 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
 # uid           [ unknown] Swift 6.x Release Signing Key <swift-infrastructure@forums.swift.org>
 ARG SWIFT_SIGNING_KEY=52BB7E3DE28A71BE22EC05FFEF80A866B47A981F
 ARG SWIFT_PLATFORM=debian12
-ARG SWIFT_BRANCH=swift-6.3.2-release
-ARG SWIFT_VERSION=swift-6.3.2-RELEASE
+ARG SWIFT_BRANCH=swift-6.3.3-release
+ARG SWIFT_VERSION=swift-6.3.3-RELEASE
 ARG SWIFT_WEBROOT=https://download.swift.org
 
 ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \

--- a/6.3/debian/12/slim/Dockerfile
+++ b/6.3/debian/12/slim/Dockerfile
@@ -16,8 +16,8 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
 # uid           [ unknown] Swift 6.x Release Signing Key <swift-infrastructure@forums.swift.org>
 ARG SWIFT_SIGNING_KEY=52BB7E3DE28A71BE22EC05FFEF80A866B47A981F
 ARG SWIFT_PLATFORM=debian12
-ARG SWIFT_BRANCH=swift-6.3.2-release
-ARG SWIFT_VERSION=swift-6.3.2-RELEASE
+ARG SWIFT_BRANCH=swift-6.3.3-release
+ARG SWIFT_VERSION=swift-6.3.3-RELEASE
 ARG SWIFT_WEBROOT=https://download.swift.org
 
 ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \

--- a/6.3/fedora/39/Dockerfile
+++ b/6.3/fedora/39/Dockerfile
@@ -25,8 +25,8 @@ RUN yum -y install \
 # uid           [ unknown] Swift 6.x Release Signing Key <swift-infrastructure@forums.swift.org>
 ARG SWIFT_SIGNING_KEY=52BB7E3DE28A71BE22EC05FFEF80A866B47A981F
 ARG SWIFT_PLATFORM=fedora39
-ARG SWIFT_BRANCH=swift-6.3.2-release
-ARG SWIFT_VERSION=swift-6.3.2-RELEASE
+ARG SWIFT_BRANCH=swift-6.3.3-release
+ARG SWIFT_VERSION=swift-6.3.3-RELEASE
 ARG SWIFT_WEBROOT=https://download.swift.org
 
 ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \

--- a/6.3/fedora/39/slim/Dockerfile
+++ b/6.3/fedora/39/slim/Dockerfile
@@ -10,8 +10,8 @@ LABEL description="Docker Container for the Swift programming language"
 # uid           [ unknown] Swift 6.x Release Signing Key <swift-infrastructure@forums.swift.org>
 ARG SWIFT_SIGNING_KEY=52BB7E3DE28A71BE22EC05FFEF80A866B47A981F
 ARG SWIFT_PLATFORM=fedora39
-ARG SWIFT_BRANCH=swift-6.3.2-release
-ARG SWIFT_VERSION=swift-6.3.2-RELEASE
+ARG SWIFT_BRANCH=swift-6.3.3-release
+ARG SWIFT_VERSION=swift-6.3.3-RELEASE
 ARG SWIFT_WEBROOT=https://download.swift.org
 
 ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \

--- a/6.3/rhel-ubi/9/Dockerfile
+++ b/6.3/rhel-ubi/9/Dockerfile
@@ -23,8 +23,8 @@ RUN yum -y install \
 # uid           [ unknown] Swift 6.x Release Signing Key <swift-infrastructure@forums.swift.org>
 ARG SWIFT_SIGNING_KEY=52BB7E3DE28A71BE22EC05FFEF80A866B47A981F
 ARG SWIFT_PLATFORM=ubi9
-ARG SWIFT_BRANCH=swift-6.3.2-release
-ARG SWIFT_VERSION=swift-6.3.2-RELEASE
+ARG SWIFT_BRANCH=swift-6.3.3-release
+ARG SWIFT_VERSION=swift-6.3.3-RELEASE
 ARG SWIFT_WEBROOT=https://download.swift.org
 
 ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \

--- a/6.3/rhel-ubi/9/slim/Dockerfile
+++ b/6.3/rhel-ubi/9/slim/Dockerfile
@@ -9,8 +9,8 @@ LABEL description="Docker Container for the Swift programming language"
 # uid           [ unknown] Swift 6.x Release Signing Key <swift-infrastructure@forums.swift.org>
 ARG SWIFT_SIGNING_KEY=52BB7E3DE28A71BE22EC05FFEF80A866B47A981F
 ARG SWIFT_PLATFORM=ubi9
-ARG SWIFT_BRANCH=swift-6.3.2-release
-ARG SWIFT_VERSION=swift-6.3.2-RELEASE
+ARG SWIFT_BRANCH=swift-6.3.3-release
+ARG SWIFT_VERSION=swift-6.3.3-RELEASE
 ARG SWIFT_WEBROOT=https://download.swift.org
 
 ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \

--- a/6.3/ubuntu/22.04/Dockerfile
+++ b/6.3/ubuntu/22.04/Dockerfile
@@ -30,8 +30,8 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
 # uid           [ unknown] Swift 6.x Release Signing Key <swift-infrastructure@forums.swift.org>
 ARG SWIFT_SIGNING_KEY=52BB7E3DE28A71BE22EC05FFEF80A866B47A981F
 ARG SWIFT_PLATFORM=ubuntu22.04
-ARG SWIFT_BRANCH=swift-6.3.2-release
-ARG SWIFT_VERSION=swift-6.3.2-RELEASE
+ARG SWIFT_BRANCH=swift-6.3.3-release
+ARG SWIFT_VERSION=swift-6.3.3-RELEASE
 ARG SWIFT_WEBROOT=https://download.swift.org
 
 ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \

--- a/6.3/ubuntu/22.04/slim/Dockerfile
+++ b/6.3/ubuntu/22.04/slim/Dockerfile
@@ -16,8 +16,8 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
 # uid           [ unknown] Swift 6.x Release Signing Key <swift-infrastructure@forums.swift.org>
 ARG SWIFT_SIGNING_KEY=52BB7E3DE28A71BE22EC05FFEF80A866B47A981F
 ARG SWIFT_PLATFORM=ubuntu22.04
-ARG SWIFT_BRANCH=swift-6.3.2-release
-ARG SWIFT_VERSION=swift-6.3.2-RELEASE
+ARG SWIFT_BRANCH=swift-6.3.3-release
+ARG SWIFT_VERSION=swift-6.3.3-RELEASE
 ARG SWIFT_WEBROOT=https://download.swift.org
 
 ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \

--- a/6.3/ubuntu/24.04/Dockerfile
+++ b/6.3/ubuntu/24.04/Dockerfile
@@ -30,8 +30,8 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
 # uid           [ unknown] Swift 6.x Release Signing Key <swift-infrastructure@forums.swift.org>
 ARG SWIFT_SIGNING_KEY=52BB7E3DE28A71BE22EC05FFEF80A866B47A981F
 ARG SWIFT_PLATFORM=ubuntu24.04
-ARG SWIFT_BRANCH=swift-6.3.2-release
-ARG SWIFT_VERSION=swift-6.3.2-RELEASE
+ARG SWIFT_BRANCH=swift-6.3.3-release
+ARG SWIFT_VERSION=swift-6.3.3-RELEASE
 ARG SWIFT_WEBROOT=https://download.swift.org
 
 ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \

--- a/6.3/ubuntu/24.04/slim/Dockerfile
+++ b/6.3/ubuntu/24.04/slim/Dockerfile
@@ -17,8 +17,8 @@ RUN export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true && ap
 # uid           [ unknown] Swift 6.x Release Signing Key <swift-infrastructure@forums.swift.org>
 ARG SWIFT_SIGNING_KEY=52BB7E3DE28A71BE22EC05FFEF80A866B47A981F
 ARG SWIFT_PLATFORM=ubuntu24.04
-ARG SWIFT_BRANCH=swift-6.3.2-release
-ARG SWIFT_VERSION=swift-6.3.2-RELEASE
+ARG SWIFT_BRANCH=swift-6.3.3-release
+ARG SWIFT_VERSION=swift-6.3.3-RELEASE
 ARG SWIFT_WEBROOT=https://download.swift.org
 
 ENV SWIFT_SIGNING_KEY=$SWIFT_SIGNING_KEY \

--- a/6.3/windows/1809/Dockerfile
+++ b/6.3/windows/1809/Dockerfile
@@ -122,8 +122,8 @@ RUN Write-Host -NoNewLine ('Downloading {0} ... ' -f ${env:VSB});               
     Remove-Item -ErrorAction SilentlyContinue -Force -Recurse ${env:TEMP}\*
 
 # Install Swift toolchain.
-ARG SWIFT=https://download.swift.org/swift-6.3.2-release/windows10/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE-windows10.exe
-ARG SWIFT_SHA256=F5158308A937C0E9CBAA538993F7C2E46BD77CE56F271659F7A0629E6037092E
+ARG SWIFT=https://download.swift.org/swift-6.3.3-release/windows10/swift-6.3.3-RELEASE/swift-6.3.3-RELEASE-windows10.exe
+ARG SWIFT_SHA256=235626548F249CD516D3D4D90EEE980DCCAD46F3822DAC1F8E3119B0FEDE94B7
 RUN Write-Host -NoNewLine ('Downloading {0} ... ' -f ${env:SWIFT});             \
     Invoke-WebRequest -Uri ${env:SWIFT} -OutFile installer.exe;                 \
     Write-Host '✓';                                                             \

--- a/6.3/windows/LTSC2022/Dockerfile
+++ b/6.3/windows/LTSC2022/Dockerfile
@@ -122,8 +122,8 @@ RUN Write-Host -NoNewLine ('Downloading {0} ... ' -f ${env:VSB});               
     Remove-Item -ErrorAction SilentlyContinue -Force -Recurse ${env:TEMP}\*
 
 # Install Swift toolchain.
-ARG SWIFT=https://download.swift.org/swift-6.3.2-release/windows10/swift-6.3.2-RELEASE/swift-6.3.2-RELEASE-windows10.exe
-ARG SWIFT_SHA256=F5158308A937C0E9CBAA538993F7C2E46BD77CE56F271659F7A0629E6037092E
+ARG SWIFT=https://download.swift.org/swift-6.3.3-release/windows10/swift-6.3.3-RELEASE/swift-6.3.3-RELEASE-windows10.exe
+ARG SWIFT_SHA256=235626548F249CD516D3D4D90EEE980DCCAD46F3822DAC1F8E3119B0FEDE94B7
 RUN Write-Host -NoNewLine ('Downloading {0} ... ' -f ${env:SWIFT});             \
     Invoke-WebRequest -Uri ${env:SWIFT} -OutFile installer.exe;                 \
     Write-Host '✓';                                                             \


### PR DESCRIPTION
## Summary

- Update `SWIFT_BRANCH` and `SWIFT_VERSION` from `6.3.2` to `6.3.3` across all 6.3 Dockerfiles (Ubuntu, Debian, Amazon Linux, Fedora, RHEL UBI, Windows)
- Update Windows `SWIFT_SHA256` to `235626548F249CD516D3D4D90EEE980DCCAD46F3822DAC1F8E3119B0FEDE94B7` for the 6.3.3 release installer